### PR TITLE
feat: Add get_vat_by_value

### DIFF
--- a/src/viur/shop/modules/vat.py
+++ b/src/viur/shop/modules/vat.py
@@ -18,6 +18,6 @@ class Vat(ShopModuleAbstract, List):
         return admin_info
 
     def get_vat_by_value(self, vat_percent: float) -> db.Key:
-        if not(skel := self.viewSkel().all().mergeExternalFilter({"rate": vat_percent}).getSkel()):
+        if not (skel := self.viewSkel().all().mergeExternalFilter({"rate": vat_percent}).getSkel()):
             raise errors.NotFound("Vat not found")
         return skel

--- a/src/viur/shop/modules/vat.py
+++ b/src/viur/shop/modules/vat.py
@@ -1,4 +1,4 @@
-from viur.core import db,errors
+from viur.core import db, errors
 from viur.core.prototypes import List
 
 from .abstract import ShopModuleAbstract

--- a/src/viur/shop/modules/vat.py
+++ b/src/viur/shop/modules/vat.py
@@ -1,4 +1,4 @@
-from viur.core import db
+from viur.core import db,errors
 from viur.core.prototypes import List
 
 from .abstract import ShopModuleAbstract
@@ -16,3 +16,8 @@ class Vat(ShopModuleAbstract, List):
         admin_info = super().adminInfo()
         admin_info["icon"] = "cash-stack"
         return admin_info
+
+    def get_vat_by_value(self, vat_percent: float) -> db.Key:
+        if not(skel := self.viewSkel().all().mergeExternalFilter({"rate": vat_percent}).getSkel()):
+            raise errors.NotFound("Vat not found")
+        return skel


### PR DESCRIPTION
Add mehtod for geting a vat form the vat rate. Can be uesd for migration old values. Like:

```python
        if not skel["shop_vat"]:
            try:
                key = conf.main_app.shop.vat.get_vat_by_value(tax)["key"]
                skel.setBoneValue("shop_vat", key)
            except Exception as e:
                logging.error(e)  # Todo shop logger
```