### PR TITLE
feat: Implement shipping calculation and restructure Skeletons

### DIFF
--- a/src/viur/shop/data/translations.py
+++ b/src/viur/shop/data/translations.py
@@ -353,6 +353,11 @@ TRANSLATIONS = {
         "en": "Shop price retail",
         "fr": "",
     },
+    "viur.shop.skeleton.cartitem.shop_shipping_config": {
+        "_hint": "bone shop_shipping<RelationalBone> in CartItemSkel in viur.shop",
+        "de": "Versand Konfiguration",
+        "en": "Shop shipping configuration",
+    },
     "viur.shop.skeleton.cartitem.shop_shipping": {
         "_hint": "bone shop_shipping<RelationalBone> in CartItemSkel in viur.shop",
         "de": "Versand",
@@ -731,11 +736,10 @@ TRANSLATIONS = {
         "en": "Name",
         "fr": "Nom",
     },
-    "viur.shop.skeleton.shippingconfig.shipping_skel": {
+    "viur.shop.skeleton.shippingconfig.shipping": {
         "_hint": "bone shipping_skel<RelationalBone> in ShippingConfigSkel in viur.shop",
-        "de": "Versand skel",
-        "en": "Shipping skel",
-        "fr": "",
+        "de": "Versand",
+        "en": "Shipping",
     },
     "viur.shop.skeleton.vat.name": {
         "_hint": "bone name<StringBone> in VatSkel in viur.shop",

--- a/src/viur/shop/modules/address.py
+++ b/src/viur/shop/modules/address.py
@@ -6,7 +6,6 @@ from viur.core.prototypes.skelmodule import DEFAULT_ORDER_TYPE
 from viur.core.skeleton import SkeletonInstance
 from .abstract import ShopModuleAbstract
 from ..globals import SHOP_LOGGER
-from viur.core.prototypes.skelmodule import ORDER_TYPE
 
 logger = SHOP_LOGGER.getChild(__name__)
 

--- a/src/viur/shop/modules/api.py
+++ b/src/viur/shop/modules/api.py
@@ -7,7 +7,11 @@ from viur.core import db, errors, exposed, force_post
 from viur.core.render.json.default import DefaultRender as JsonRenderer
 from viur.shop.modules.abstract import ShopModuleAbstract
 from viur.shop.types import *
+from viur.shop.skeletons import ShippingSkel
 from ..globals import SENTINEL, SHOP_INSTANCE_VI, SHOP_LOGGER
+
+# if t.TYPE_CHECKING:
+#     from .. import ShippingSkel
 
 logger = SHOP_LOGGER.getChild(__name__)
 
@@ -375,13 +379,18 @@ class Api(ShopModuleAbstract):
     def shipping_list(
         self,
         cart_key: str | db.Key,
-    ):
+    ) -> JsonResponse[list[SkeletonInstance_T[ShippingSkel]]]:
         """
-        Listet verfügbar Versandoptionen für einen (Unter)Warenkorb auf
-        """
-        ...
+        Lists available shipping options for a (sub)cart
 
-    # --- Internal helpers  ----------------------------------------------------
+        :param cart_key: Key of the parent cart
+
+        :returns: list of :class:`ShippingSkel` `SkeletonInstance`s
+        """
+        cart_key = self._normalize_external_key(cart_key, "cart_key")
+        return JsonResponse(self.shop.shipping.get_shipping_skels_for_cart(cart_key))
+
+        # --- Internal helpers  ----------------------------------------------------
 
     def _normalize_external_key(
         self,

--- a/src/viur/shop/modules/api.py
+++ b/src/viur/shop/modules/api.py
@@ -6,12 +6,9 @@ import viur.shop.types.exceptions as e
 from viur.core import db, errors, exposed, force_post
 from viur.core.render.json.default import DefaultRender as JsonRenderer
 from viur.shop.modules.abstract import ShopModuleAbstract
-from viur.shop.types import *
 from viur.shop.skeletons import ShippingSkel
+from viur.shop.types import *
 from ..globals import SENTINEL, SHOP_INSTANCE_VI, SHOP_LOGGER
-
-# if t.TYPE_CHECKING:
-#     from .. import ShippingSkel
 
 logger = SHOP_LOGGER.getChild(__name__)
 
@@ -390,7 +387,7 @@ class Api(ShopModuleAbstract):
         cart_key = self._normalize_external_key(cart_key, "cart_key")
         return JsonResponse(self.shop.shipping.get_shipping_skels_for_cart(cart_key))
 
-        # --- Internal helpers  ----------------------------------------------------
+    # --- Internal helpers  ----------------------------------------------------
 
     def _normalize_external_key(
         self,

--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -164,13 +164,13 @@ class Cart(ShopModuleAbstract, Tree):
     def get_children(
         self,
         parent_cart_key: db.Key,
-        **kwargs
+        **filters: t.Any,
     ) -> t.Iterator[SkeletonInstance]:
         if not isinstance(parent_cart_key, db.Key):
             raise TypeError(f"parent_cart_key must be an instance of db.Key")
         for skel_type in ("node", "leaf"):
             skel = self.viewSkel(skel_type)
-            query = skel.all().mergeExternalFilter(kwargs)
+            query = skel.all().mergeExternalFilter(filters)
             query = query.order(("sortindex", db.SortOrder.Ascending))
             # TODO: query = self.listFilter(query)
             if query is None:

--- a/src/viur/shop/modules/shipping.py
+++ b/src/viur/shop/modules/shipping.py
@@ -82,8 +82,6 @@ class Shipping(ShopModuleAbstract, List):
                 if issubclass(child.skeletonCls, CartNodeSkel):
                     logger.debug(f"{child=}")
                     queue.append(child["key"])
-                    ...
-                    # TODO: we ignore currently the sub card
                 else:
                     logger.debug(f"{child=} | {child.article_skel=}")
                     logger.debug(f'{child.article_skel["shop_shipping_config"]=}')

--- a/src/viur/shop/modules/shipping.py
+++ b/src/viur/shop/modules/shipping.py
@@ -2,11 +2,10 @@ import collections
 import itertools
 import typing as t
 
-from viur import toolkit
 from viur.core import db, errors
 from viur.core.prototypes import List
-from viur.core.skeleton import RefSkel, SkeletonInstance
-from viur.shop.skeletons import CartNodeSkel, ShippingSkel
+from viur.core.skeleton import RefSkel
+from viur.shop.skeletons import ArticleAbstractSkel, CartNodeSkel, ShippingSkel
 from viur.shop.types import SkeletonInstance_T
 from .abstract import ShopModuleAbstract
 from ..globals import SHOP_LOGGER
@@ -24,8 +23,8 @@ class Shipping(ShopModuleAbstract, List):
 
     def choose_shipping_skel_for_article(
         self,
-        article_skel: SkeletonInstance
-    ) -> SkeletonInstance | None | t.Literal[False]:
+        article_skel: SkeletonInstance_T[ArticleAbstractSkel]
+    ) -> SkeletonInstance_T[ShippingSkel] | None | t.Literal[False]:
         """
         Chooses always the cheapest, applicable shipping for an article
 
@@ -33,26 +32,22 @@ class Shipping(ShopModuleAbstract, List):
 
         # TODO(discuss): List all options?
         """
-        logger.debug(f'choose_shipping_skel_for_article({article_skel["key"]=}'
-                     f' | {article_skel["shop_shipping_config"]=})')
-
         if not article_skel["shop_shipping_config"]:
             logger.debug(f'{article_skel["key"]} has no shop_shipping set.')  # TODO: fallback??
             return None
 
-        shipping_config_skel = toolkit.get_full_skel_from_ref_skel(article_skel["shop_shipping_config"]["dest"])
+        shipping_config_skel = article_skel["shop_shipping_config"]["dest"]
         logger.debug(f"{shipping_config_skel=}")
 
         applicable_shippings = []
         for shipping in shipping_config_skel["shipping"]:
-            logger.debug(f"{shipping=}")
             is_applicable, reason = self.shop.shipping_config.is_applicable(
                 shipping["dest"], shipping["rel"], article_skel=article_skel)
             logger.debug(f"{shipping=} --> {is_applicable=} | {reason=}")
             if is_applicable:
                 applicable_shippings.append(shipping)
 
-        logger.debug(f"{applicable_shippings=}")
+        logger.debug(f"<{len(applicable_shippings)}>{applicable_shippings=}")
         if not applicable_shippings:
             logger.error("No suitable shipping found")  # TODO: fallback??
             return False
@@ -70,8 +65,6 @@ class Shipping(ShopModuleAbstract, List):
         :param cart_key: Key of the parent cart node, can be a sub-cart too
         :return: A list of :class:`SkeletonInstance`s for the :class:`ShippingSkel`.
         """
-        logger.debug(f'get_shipping_skels_for_cart({cart_key=!r})')
-
         cart_skel = self.shop.cart.viewSkel("node")
         if not cart_skel.fromDB(cart_key):
             raise errors.NotFound

--- a/src/viur/shop/modules/shipping.py
+++ b/src/viur/shop/modules/shipping.py
@@ -1,6 +1,9 @@
-from viur.core.prototypes import List
-from .abstract import ShopModuleAbstract
+import typing as t
 
+from viur import toolkit
+from viur.core.prototypes import List
+from viur.core.skeleton import SkeletonInstance
+from .abstract import ShopModuleAbstract
 from ..globals import SHOP_LOGGER
 
 logger = SHOP_LOGGER.getChild(__name__)
@@ -13,3 +16,34 @@ class Shipping(ShopModuleAbstract, List):
         admin_info = super().adminInfo()
         admin_info["icon"] = "truck"
         return admin_info
+
+    def choose_shipping_skel_for_article(
+        self,
+        article_skel: SkeletonInstance
+    ) -> SkeletonInstance | None | t.Literal[False]:
+        logger.debug(f'choose_shipping_skel_for_article({article_skel["key"]=} | {article_skel["shop_shipping_config"]=} | )')
+
+        if not article_skel["shop_shipping_config"]:
+            logger.debug(f'{article_skel["key"]} has no shop_shipping set.')  # TODO: fallback??
+            return None
+
+        shipping_config_skel = toolkit.get_full_skel_from_ref_skel(article_skel["shop_shipping_config"]["dest"])
+        logger.debug(f"{shipping_config_skel=}")
+
+        applicable_shippings = []
+        for shipping in shipping_config_skel["shipping"]:
+            logger.debug(f"{shipping=}")
+            is_applicable, reason = self.shop.shipping_config.is_applicable(
+                shipping["dest"], shipping["rel"], article_skel, None)
+            logger.debug(f"{shipping=} --> {is_applicable=} | {reason=}")
+            if is_applicable:
+                applicable_shippings.append(shipping)
+
+        logger.debug(f"{applicable_shippings=}")
+        if not applicable_shippings:
+            logger.error("No suitable shipping found")  # TODO: fallback??
+            return False
+
+        cheapest_shipping = min(applicable_shippings, key=lambda shipping: shipping["dest"]["shipping_cost"] or 0)
+        logger.debug(f"{cheapest_shipping=}")
+        return cheapest_shipping

--- a/src/viur/shop/modules/shipping.py
+++ b/src/viur/shop/modules/shipping.py
@@ -62,6 +62,8 @@ class Shipping(ShopModuleAbstract, List):
     ) -> list[SkeletonInstance_T[ShippingSkel]]:
         """Get all configured and applicable shippings of all items in the cart
 
+        # TODO: how do we handle free shipping discounts?
+
         :param cart_key: Key of the parent cart node, can be a sub-cart too
         :return: A list of :class:`SkeletonInstance`s for the :class:`ShippingSkel`.
         """

--- a/src/viur/shop/modules/shipping.py
+++ b/src/viur/shop/modules/shipping.py
@@ -1,10 +1,15 @@
+import collections
+import itertools
 import typing as t
 
 from viur import toolkit
 from viur.core.prototypes import List
-from viur.core.skeleton import SkeletonInstance
+from viur.core.skeleton import RefSkel, SkeletonInstance
 from .abstract import ShopModuleAbstract
+from viur.shop.skeletons import CartNodeSkel, ShippingSkel
+from viur.shop.types import  SkeletonInstance_T
 from ..globals import SHOP_LOGGER
+from viur.core import db, errors
 
 logger = SHOP_LOGGER.getChild(__name__)
 
@@ -21,6 +26,13 @@ class Shipping(ShopModuleAbstract, List):
         self,
         article_skel: SkeletonInstance
     ) -> SkeletonInstance | None | t.Literal[False]:
+        """
+        Chooses alwass the cheapest, applicable shipping for an article
+
+        Ignores the supplier
+
+        # TODO(discuss): List all options?
+        """
         logger.debug(f'choose_shipping_skel_for_article({article_skel["key"]=} | {article_skel["shop_shipping_config"]=} | )')
 
         if not article_skel["shop_shipping_config"]:
@@ -43,6 +55,72 @@ class Shipping(ShopModuleAbstract, List):
         if not applicable_shippings:
             logger.error("No suitable shipping found")  # TODO: fallback??
             return False
+
+        cheapest_shipping = min(applicable_shippings, key=lambda shipping: shipping["dest"]["shipping_cost"] or 0)
+        logger.debug(f"{cheapest_shipping=}")
+        return cheapest_shipping
+
+    def get_shipping_skels_for_cart(
+        self,
+        cart_key: db.Key
+    ) -> list[SkeletonInstance_T[ShippingSkel]]:
+        logger.debug(f'get_shipping_skels_for_cart({cart_key=!r})')
+
+        cart_skel = self.shop.cart.viewSkel("node")
+        if not cart_skel.fromDB(cart_key):
+            raise errors.NotFound
+
+        all_shipping_configs : list[RefSkel] = []
+
+        queue = collections.deque([cart_key])
+        while queue:
+            parent_cart_key = queue.pop()
+            logger.debug(f"{parent_cart_key=} | {queue=}")
+
+            for child in self.shop.cart.get_children(parent_cart_key):
+                if issubclass(child.skeletonCls, CartNodeSkel):
+                    logger.debug(f"{child=}")
+                    queue.append(child["key"])
+                    ...
+                    # TODO: we ignore currently the sub card
+                else:
+                    logger.debug(f"{child=} | {child.article_skel=}")
+                    logger.debug(f'{child.article_skel["shop_shipping_config"]=}')
+                    if child.article_skel["shop_shipping_config"] is not None:
+                        all_shipping_configs.append(child.article_skel["shop_shipping_config"]["dest"])
+
+        logger.debug(f"(before de-duplication) <{len(all_shipping_configs)}>{all_shipping_configs=}")
+        # eliminate duplicates
+        all_shipping_configs = ({sc["key"]: sc for sc in all_shipping_configs}).values()
+        logger.debug(f"(after de-duplication) <{len(all_shipping_configs)}>{all_shipping_configs=}")
+
+        if not all_shipping_configs:
+            logger.debug(f'{cart_key=!r}\'s articles have no shop_shipping_config set.')  # TODO: fallback??
+            return []
+
+        shipping_config_skels = list(map(toolkit.get_full_skel_from_ref_skel, all_shipping_configs))
+        logger.debug(f"{shipping_config_skels=}")
+
+        all_shipping = itertools.chain.from_iterable(
+            shipping_config_skel["shipping"] or []
+            for shipping_config_skel in shipping_config_skels
+        )
+
+        applicable_shippings : list[SkeletonInstance_T[ShippingSkel]] = []
+        for shipping in all_shipping:
+            logger.debug(f"{shipping=}")
+            is_applicable, reason = self.shop.shipping_config.is_applicable(
+                shipping["dest"], shipping["rel"], None, cart_skel)
+            logger.debug(f"{shipping=} --> {is_applicable=} | {reason=}")
+            if is_applicable:
+                applicable_shippings.append(shipping)
+
+        logger.debug(f"{applicable_shippings=}")
+        if not applicable_shippings:
+            logger.error("No suitable shipping found")  # TODO: fallback??
+            return []
+
+        return applicable_shippings
 
         cheapest_shipping = min(applicable_shippings, key=lambda shipping: shipping["dest"]["shipping_cost"] or 0)
         logger.debug(f"{cheapest_shipping=}")

--- a/src/viur/shop/modules/shipping_config.py
+++ b/src/viur/shop/modules/shipping_config.py
@@ -27,6 +27,12 @@ class ShippingConfig(ShopModuleAbstract, List):
         article_skel: SkeletonInstance_T[ArticleSkel] | None = None,  # ArticleSkel
         cart_skel: SkeletonInstance_T[CartNodeSkel] | None = None,  # CartNodeSkel
     ) -> tuple[bool, str]:
+        """
+        Check if a shipping configuration is applicable in the current context.
+
+        Provide eiter `article_skel` for single article context
+        xor `cart_skel` for cart context.
+        """
         logger.debug(f'is_applicable({dest=}, {rel=}, {article_skel and article_skel["key"]=!r}, {cart_skel=})')
 
         if not ((article_skel is None) ^ (cart_skel is None)):

--- a/src/viur/shop/modules/shipping_config.py
+++ b/src/viur/shop/modules/shipping_config.py
@@ -22,7 +22,7 @@ class ShippingConfig(ShopModuleAbstract, List):
         article_skel: SkeletonInstance,  # ArticleSkel
         cart_skel: SkeletonInstance | None = None,  # CartNodeSkel
     ) -> tuple[bool, str]:
-        logger.debug(f'is_applicable({dest=}, {rel=}, {article_skel["key"]=!r}, {cart_skel=})')
+        logger.debug(f'is_applicable({dest=}, {rel=}, {article_skel and article_skel["key"]=!r}, {cart_skel=})')
 
         if rel["minimum_order_value"]:
             if cart_skel is None:

--- a/src/viur/shop/modules/shipping_config.py
+++ b/src/viur/shop/modules/shipping_config.py
@@ -2,6 +2,7 @@ from viur.core.prototypes import List
 from .abstract import ShopModuleAbstract
 
 from ..globals import SHOP_LOGGER
+from ...core.skeleton import SkeletonInstance
 
 logger = SHOP_LOGGER.getChild(__name__)
 
@@ -13,3 +14,25 @@ class ShippingConfig(ShopModuleAbstract, List):
         admin_info = super().adminInfo()
         admin_info["icon"] = "truck-flatbed"
         return admin_info
+
+    def is_applicable(
+        self,
+        dest,
+        rel,
+        article_skel: SkeletonInstance,  # ArticleSkel
+        cart_skel: SkeletonInstance | None = None,  # CartNodeSkel
+    ) -> tuple[bool, str]:
+        logger.debug(f'is_applicable({dest=}, {rel=}, {article_skel["key"]=!r}, {cart_skel=})')
+
+        if rel["minimum_order_value"]:
+            if cart_skel is None:
+                if article_skel.shop_price_.current < rel["minimum_order_value"]:
+                    return False, "< minimum_order_value [article]"
+            else:
+                if cart_skel["total"] < rel["minimum_order_value"]:
+                    return False, "< minimum_order_value [cart]"
+
+        if rel["country"]: ...  # TODO
+        if rel["zip_code"]: ...  # TODO
+
+        return True, ""

--- a/src/viur/shop/services/hooks.py
+++ b/src/viur/shop/services/hooks.py
@@ -1,24 +1,46 @@
+"""Customization / hook service
+
+Register own implementations (:class:`Customization`) to influence
+a specific behavior (:class:`Hook`) of the viur-shop.
+"""
+
 import abc
 import enum
 import typing as t
 
+from viur.shop.types.exceptions import DispatchError
 from ..globals import SHOP_LOGGER
 
 logger = SHOP_LOGGER.getChild(__name__)
 
 
 class Hook(enum.IntEnum):
+    """The hook'able events / actions."""
+
     ORDER_ASSIGN_UID = enum.auto()
+    """
+    Hook that assign a order id on a OrderSkel
+    type: (order_skel: SkeletonInstance_T[OrderSkel]) -> SkeletonInstance_T[OrderSkel]
+    """
+
+    CURRENT_COUNTRY = enum.auto()
+    """Provide the country of a global site context
+    type: (context: t.Literal["cart", "article"]) -> str
+    """
 
 
 class Customization(abc.ABC):
+    """Abstract base class for own implementations."""
+
     @property
     @abc.abstractmethod
     def kind(self) -> Hook:
+        """The action this implementation is for"""
         ...
 
     @abc.abstractmethod
     def __call__(self, *args, **kwargs) -> t.Any:
+        """The main logic of this implementation"""
         ...
 
     def __repr__(self) -> str:
@@ -26,6 +48,7 @@ class Customization(abc.ABC):
 
     @classmethod
     def from_method(cls, func: t.Callable, kind: Hook) -> t.Self:
+        """Just a handy variant to define an implementation without a class definition"""
         return type(
             f"{kind}_{func.__name__}{cls.__name__}",
             (cls,),
@@ -36,9 +59,25 @@ class Customization(abc.ABC):
 class HookService:
     customizations: t.Final[list[Customization]] = []
 
-    def register(self, customization: Customization):
+    def register(self, customization: Customization | t.Type[Customization]) -> Customization:
+        """Register a customization with this service
+
+        Can be used as class decorator too
+
+        .. code-block:: python
+
+            @HOOK_SERVICE.register
+            class MyImplementation(Customization):
+                kind = Hook.ORDER_ASSIGN_UID
+
+                def __call__(self, *args, **kwargs) -> t.Any:
+                    ...
+        """
         if not isinstance(customization, Customization):
-            raise TypeError(f"customization must be of type Customization")
+            if issubclass(customization, Customization):
+                customization = customization()
+            else:
+                raise TypeError(f"customization must be of type Customization")
         # TODO: What happens on existing hooks for the same kind?
         HookService.customizations.append(customization)
         return customization
@@ -46,14 +85,14 @@ class HookService:
     def unregister(self, customization: Customization):
         HookService.customizations.remove(customization)
 
-    def dispatch(self, kind: Customization, default: t.Callable = None):
+    def dispatch(self, kind: Hook, default: t.Callable = None) -> t.Callable:
         for customization in HookService.customizations:
             if kind is customization.kind:  # TODO: add by_kind map
                 logger.debug(f"found {customization=}")
                 return customization
         logger.debug(f"found no customization")
         if default is None:
-            raise ValueError(f"No customization found for {kind}")
+            raise DispatchError(f"No customization found for {kind}", kind)
         logger.debug(f"use default customization {default=}")
         return default
 

--- a/src/viur/shop/skeletons/address.py
+++ b/src/viur/shop/skeletons/address.py
@@ -1,7 +1,6 @@
 from viur.core.bones import *
 from viur.core.skeleton import Skeleton
 from viur.shop.types import *
-
 from ..globals import SHOP_LOGGER
 
 logger = SHOP_LOGGER.getChild(__name__)

--- a/src/viur/shop/skeletons/article.py
+++ b/src/viur/shop/skeletons/article.py
@@ -5,9 +5,7 @@ import typing as t  # noqa
 from viur.core.bones import *
 from viur.core.skeleton import BaseSkeleton
 from viur.shop.types import *
-
 from ..globals import SHOP_INSTANCE, SHOP_LOGGER
-from viur.core import utils
 from ..types.response import make_json_dumpable
 
 logger = SHOP_LOGGER.getChild(__name__)
@@ -96,8 +94,9 @@ class ArticleAbstractSkel(BaseSkeleton):
     shop_price.type = JsonBone.type
 
     shop_shipping = RawBone(  # FIXME: JsonBone doesn't work (https://github.com/viur-framework/viur-core/issues/1092)
-        compute=Compute(lambda skel: make_json_dumpable(SHOP_INSTANCE.get().shipping.choose_shipping_skel_for_article(skel)),
-                        ComputeInterval(ComputeMethod.Always)),
+        compute=Compute(
+            lambda skel: make_json_dumpable(SHOP_INSTANCE.get().shipping.choose_shipping_skel_for_article(skel)),
+            ComputeInterval(ComputeMethod.Always)),
     )
     shop_shipping.type = JsonBone.type
     """Calculated, cheapest shipping for this article"""

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -291,6 +291,12 @@ class CartItemSkel(TreeSkel):  # STATE: Complete (as in model)
     )
     price.type = JsonBone.type
 
+    shipping = RawBone(  # FIXME: JsonBone doesn't work (https://github.com/viur-framework/viur-core/issues/1092)
+        compute=Compute(lambda skel: SHOP_INSTANCE.get().shipping.choose_shipping_skel_for_article(skel.article_skel_full),
+                        ComputeInterval(ComputeMethod.Always)),
+    )
+    shipping.type = JsonBone.type
+
     @classmethod
     def toDB(cls, skelValues: SkeletonInstance, update_relations: bool = True, **kwargs) -> db.Key:
         return super().toDB(skelValues, update_relations, **kwargs)

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -1,6 +1,6 @@
 import typing as t  # noqa
 
-from viur.core import conf, db
+from viur.core import db
 from viur.core.bones import *
 from viur.core.prototypes.tree import TreeSkel
 from viur.core.skeleton import SkeletonInstance
@@ -13,8 +13,8 @@ logger = SHOP_LOGGER.getChild(__name__)
 class TotalFactory:
     def __init__(
         self,
-        bone_node: str | t.Callable[["SkeletonInstance"], float | int],
-        bone_leaf: str | t.Callable[["SkeletonInstance"], float | int],
+        bone_node: str | t.Callable[[SkeletonInstance], float | int],
+        bone_leaf: str | t.Callable[[SkeletonInstance], float | int],
         multiply_quantity: bool = True,
         precision: int | None = None,
         use_cache: bool = True,
@@ -71,6 +71,7 @@ class DiscountFactory(TotalFactory):
             total,
             self.precision if self.precision is not None else bone.precision
         )
+
 
 def get_vat_rate_for_node(skel: "CartNodeSkel", bone: RelationalBone):
     children = SHOP_INSTANCE.get().cart.get_children_from_cache(skel["key"])
@@ -293,8 +294,9 @@ class CartItemSkel(TreeSkel):  # STATE: Complete (as in model)
     price.type = JsonBone.type
 
     shipping = RawBone(  # FIXME: JsonBone doesn't work (https://github.com/viur-framework/viur-core/issues/1092)
-        compute=Compute(lambda skel: SHOP_INSTANCE.get().shipping.choose_shipping_skel_for_article(skel.article_skel_full),
-                        ComputeInterval(ComputeMethod.Always)),
+        compute=Compute(
+            lambda skel: SHOP_INSTANCE.get().shipping.choose_shipping_skel_for_article(skel.article_skel_full),
+            ComputeInterval(ComputeMethod.Always)),
     )
     shipping.type = JsonBone.type
 

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -251,7 +251,6 @@ class CartItemSkel(TreeSkel):  # STATE: Complete (as in model)
         consistency=RelationalConsistency.PreventDeletion,
     )
 
-    # TODO: shop_shipping_config or shop_shipping_config ?
     shop_shipping_config = RelationalBone(
         kind="{{viur_shop_modulename}}_shipping_config",
         module="{{viur_shop_modulename}}/shipping_config",

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -200,7 +200,7 @@ class CartItemSkel(TreeSkel):  # STATE: Complete (as in model)
             "shop_price_retail", "shop_price_recommended",
             "shop_availability", "shop_listed",
             "shop_image", "shop_art_no_or_gtin",
-            "shop_vat", "shop_shipping",
+            "shop_vat", "shop_shipping_config",
             "shop_is_weee", "shop_is_low_price",
             "shop_price_current",
         ],
@@ -250,7 +250,8 @@ class CartItemSkel(TreeSkel):  # STATE: Complete (as in model)
         consistency=RelationalConsistency.PreventDeletion,
     )
 
-    shop_shipping = RelationalBone(
+    # TODO: shop_shipping_config or shop_shipping_config ?
+    shop_shipping_config = RelationalBone(
         kind="{{viur_shop_modulename}}_shipping_config",
         module="{{viur_shop_modulename}}/shipping_config",
         consistency=RelationalConsistency.SetNull,

--- a/src/viur/shop/skeletons/order.py
+++ b/src/viur/shop/skeletons/order.py
@@ -4,7 +4,7 @@ from viur.core import translate
 from viur.core.bones import *
 from viur.core.skeleton import Skeleton
 from viur.shop.types import *
-from ..globals import SHOP_LOGGER, SHOP_INSTANCE
+from ..globals import SHOP_INSTANCE, SHOP_LOGGER
 
 logger = SHOP_LOGGER.getChild(__name__)
 

--- a/src/viur/shop/skeletons/shipping_config.py
+++ b/src/viur/shop/skeletons/shipping_config.py
@@ -1,10 +1,10 @@
 import typing as t  # noqa
 
+from viur.core import db
 from viur.core.bones import *
 from viur.core.skeleton import Skeleton, SkeletonInstance
 from .shipping_precondition import ShippingPreconditionRelSkel
 from ..globals import SHOP_LOGGER
-from viur.core import db
 
 logger = SHOP_LOGGER.getChild(__name__)
 

--- a/src/viur/shop/skeletons/shipping_config.py
+++ b/src/viur/shop/skeletons/shipping_config.py
@@ -1,9 +1,10 @@
 import typing as t  # noqa
 
 from viur.core.bones import *
-from viur.core.skeleton import Skeleton
+from viur.core.skeleton import Skeleton, SkeletonInstance
 from .shipping_precondition import ShippingPreconditionRelSkel
 from ..globals import SHOP_LOGGER
+from viur.core import db
 
 logger = SHOP_LOGGER.getChild(__name__)
 
@@ -14,10 +15,25 @@ class ShippingConfigSkel(Skeleton):  # STATE: Complete (as in model)
     name = StringBone(
     )
 
-    shipping_skel = RelationalBone(
+    shipping = RelationalBone(
         kind="{{viur_shop_modulename}}_shipping",
         module="{{viur_shop_modulename}}/shipping",
         using=ShippingPreconditionRelSkel,
         consistency=RelationalConsistency.PreventDeletion,
         multiple=True,
+        refKeys={
+            "name",
+            "description",
+            "supplier",
+            "shipping_cost",
+            "delivery_time_*",
+        },
     )
+
+    @classmethod
+    def fromDB(cls, skel: SkeletonInstance, key: db.Key | int | str) -> bool:
+        # Migration after renaming
+        res = super().fromDB(skel, key)
+        if not skel.dbEntity.get("shipping"):
+            skel.dbEntity["shipping"] = skel.dbEntity.get("shipping_skel")
+        return res

--- a/src/viur/shop/skeletons/shipping_precondition.py
+++ b/src/viur/shop/skeletons/shipping_precondition.py
@@ -10,7 +10,7 @@ logger = SHOP_LOGGER.getChild(__name__)
 class ShippingPreconditionRelSkel(RelSkel):  # STATE: Complete (as in model)
     minimum_order_value = NumericBone(
         precision=2,
-        min=2,
+        min=0,
     )
 
     country = SelectCountryBone(

--- a/src/viur/shop/types/__init__.py
+++ b/src/viur/shop/types/__init__.py
@@ -1,6 +1,6 @@
 import typing as t
 
-from viur.core.skeleton import Skeleton, SkeletonInstance
+from viur.core.skeleton import Skeleton as _Skeleton, SkeletonInstance as _SkeletonInstance
 from .data import ClientError, Supplier  # noqa
 from .enums import (  # noqa
     AddressType,
@@ -18,19 +18,20 @@ from .enums import (  # noqa
     Salutation,
 )
 from .exceptions import (  # noqa
+    DispatchError,
     InvalidArgumentException,
     InvalidKeyException,
     InvalidStateError,
     ViURShopException,
-    ViURShopHttpException
+    ViURShopHttpException,
 )
 from .price import Price  # noqa
 from .response import ExtendedCustomJsonEncoder, JsonResponse  # noqa
 
-SkeletonCls_co = t.TypeVar("SkeletonCls_co", bound=t.Type[Skeleton], covariant=True)
+SkeletonCls_co = t.TypeVar("SkeletonCls_co", bound=t.Type[_Skeleton], covariant=True)
 
 
-class SkeletonInstance_T(SkeletonInstance, t.Generic[SkeletonCls_co]):
+class SkeletonInstance_T(_SkeletonInstance, t.Generic[SkeletonCls_co]):
     """This types trys to say to which SkeletonCls a SkeletonInstance belongs
 
     or in other words, it does what the viur-core failed to do.
@@ -38,4 +39,4 @@ class SkeletonInstance_T(SkeletonInstance, t.Generic[SkeletonCls_co]):
     ...
 
 
-del SkeletonInstance, Skeleton
+del _Skeleton, _SkeletonInstance

--- a/src/viur/shop/types/__init__.py
+++ b/src/viur/shop/types/__init__.py
@@ -1,3 +1,6 @@
+import typing as t
+
+from viur.core.skeleton import Skeleton, SkeletonInstance
 from .data import ClientError, Supplier  # noqa
 from .enums import (  # noqa
     AddressType,
@@ -23,3 +26,16 @@ from .exceptions import (  # noqa
 )
 from .price import Price  # noqa
 from .response import ExtendedCustomJsonEncoder, JsonResponse  # noqa
+
+SkeletonCls_co = t.TypeVar("SkeletonCls_co", bound=t.Type[Skeleton], covariant=True)
+
+
+class SkeletonInstance_T(SkeletonInstance, t.Generic[SkeletonCls_co]):
+    """This types trys to say to which SkeletonCls a SkeletonInstance belongs
+
+    or in other words, it does what the viur-core failed to do.
+    """
+    ...
+
+
+del SkeletonInstance, Skeleton

--- a/src/viur/shop/types/dc_scope.py
+++ b/src/viur/shop/types/dc_scope.py
@@ -1,5 +1,4 @@
 import abc
-import pprint
 import typing as t  # noqa
 
 from viur.core import current, utils

--- a/src/viur/shop/types/exceptions.py
+++ b/src/viur/shop/types/exceptions.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
 import typing as t
 
 from viur.core import errors
+
+if t.TYPE_CHECKING:
+    from viur.shop.services import Hook
 
 _sentinel = object()
 
@@ -11,6 +16,12 @@ class ViURShopException(Exception):
 
 class InvalidStateError(ViURShopException):
     ...
+
+
+class DispatchError(ViURShopException):
+    def __init__(self, msg: t.Any, hook: Hook, *args: t.Any) -> None:
+        super().__init__(msg, *args)
+        self.hook: hook = hook
 
 
 class ViURShopHttpException(errors.HTTPException):

--- a/src/viur/shop/types/price.py
+++ b/src/viur/shop/types/price.py
@@ -1,12 +1,11 @@
-import json
 import functools
+import json
 import typing as t  # noqa
 
+from viur import toolkit
 from viur.core import current, utils
 from viur.core.skeleton import SkeletonInstance
-
-from viur import toolkit
-from .enums import ConditionOperator, DiscountType, ApplicationDomain
+from .enums import ApplicationDomain, ConditionOperator, DiscountType
 from ..globals import SHOP_INSTANCE, SHOP_LOGGER
 
 logger = SHOP_LOGGER.getChild(__name__)

--- a/src/viur/shop/types/response.py
+++ b/src/viur/shop/types/response.py
@@ -23,12 +23,14 @@ class ExtendedCustomJsonEncoder(CustomJsonEncoder):
         return super().default(o)
 
 
-class JsonResponse:
+T = t.TypeVar("T")
+
+class JsonResponse(t.Generic[T]):
     __slots__ = ("json_data", "status_code", "content_type", "json_sort", "json_indent")
 
     def __init__(
         self,
-        json_data: t.Any,
+        json_data: T,
         *,
         status_code: int = 200,
         content_type: str = "application/json",

--- a/src/viur/shop/types/response.py
+++ b/src/viur/shop/types/response.py
@@ -51,3 +51,10 @@ class JsonResponse:
             indent=self.json_indent,
             cls=ExtendedCustomJsonEncoder,
         )
+
+
+def make_json_dumpable(value): # TODO: better solution
+    return json.loads(json.dumps(
+        value,
+        cls=ExtendedCustomJsonEncoder,
+    ))

--- a/src/viur/shop/types/response.py
+++ b/src/viur/shop/types/response.py
@@ -3,7 +3,6 @@ import json
 import typing as t
 
 from viur import toolkit
-
 from viur.core import current
 from viur.core.render.json.default import CustomJsonEncoder
 from viur.core.skeleton import SkeletonInstance
@@ -24,6 +23,7 @@ class ExtendedCustomJsonEncoder(CustomJsonEncoder):
 
 
 T = t.TypeVar("T")
+
 
 class JsonResponse(t.Generic[T]):
     __slots__ = ("json_data", "status_code", "content_type", "json_sort", "json_indent")
@@ -55,7 +55,7 @@ class JsonResponse(t.Generic[T]):
         )
 
 
-def make_json_dumpable(value): # TODO: better solution
+def make_json_dumpable(value):  # TODO: better solution
     return json.loads(json.dumps(
         value,
         cls=ExtendedCustomJsonEncoder,


### PR DESCRIPTION
- Change bones
   - **!BREAKING!** `shop_shipping` is now `shop_shipping_config` in `ArticleAbstractSkel` (`shop_shipping` is now a computed bone from this config)
- Implement `list_shipping` logic
- Implement internal logic to get cheapest shipping for an article and applicable shipping options for a cart.
- Ensure presence of all required `refKeys` in `ArticleAbstractSkel` implementation.
- General improvements of typing, `HookService` and more