### PR TITLE
fix: Set `module` of `article` bone in `CartItemSkel` explicit

### DIFF
--- a/src/viur/shop/shop.py
+++ b/src/viur/shop/shop.py
@@ -131,6 +131,7 @@ class Shop(InstancedModule, Module):
             )
         from viur.shop import CartItemSkel  # import must stay here to avoid circular imports
         CartItemSkel.article.kind = self.article_skel.kindName
+        CartItemSkel.article.module = self.article_skel.kindName
         DiscountConditionSkel.scope_article.kind = self.article_skel.kindName
         DiscountConditionSkel.scope_article.module = self.article_skel.kindName
         DiscountSkel.free_article.kind = self.article_skel.kindName

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -205,6 +205,7 @@ class CartItemSkel(TreeSkel):  # STATE: Complete (as in model)
 
     article = RelationalBone(
         kind="...",  # will be set in Shop._set_kind_names()
+        module="...",  # will be set in Shop._set_kind_names()
         # FIXME: What's necessary here?
         parentKeys=["key", "parententry", "article"],
         refKeys=[


### PR DESCRIPTION
Otherwise, the `RelationalBone` copies `...` as module