### PR TITLE
feat: Make `scope_code` caseINsenstive

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -24,7 +24,7 @@ indexes:
   properties:
   - name: is_subcode
   - name: parent_code.dest.__key__
-  - name: scope_code
+  - name: scope_code.idx
 
 - kind: shop_address
   properties:

--- a/src/viur/shop/data/translations.py
+++ b/src/viur/shop/data/translations.py
@@ -672,6 +672,10 @@ TRANSLATIONS = {
         "de": "Geltungsbereich: Code",
         "en": "Scope: code",
     },
+    "viur.shop.skeleton.discountcondition.scope_code.allowed_characters": {
+        "de": "Erlaubte Zeichen: {{chars}}",
+        "en": "Allowed characters: {{chars}}",
+    },
     "viur.shop.skeleton.discountcondition.scope_combinable_low_price": {
         "_hint": "bone scope_combinable_low_price<BooleanBone> in DiscountConditionSkel in viur.shop",
         "de": "Geltungsbereich: kombinierbar mit Dauertiefpreis Artikeln?",

--- a/src/viur/shop/modules/discount_condition.py
+++ b/src/viur/shop/modules/discount_condition.py
@@ -14,7 +14,7 @@ from ..types import CodeType
 
 logger = SHOP_LOGGER.getChild(__name__)
 
-CODE_CHARS = sorted(set(string.ascii_letters + string.digits).difference(set("0OIl1")))
+CODE_CHARS = sorted(set(string.ascii_uppercase + string.digits).difference(set("0OIl1")))
 CODE_LENGTH = 8
 SUFFIX_LENGTH = 6
 
@@ -146,7 +146,7 @@ class DiscountCondition(ShopModuleAbstract, List):
     # --- Apply logic ---------------------------------------------------------
 
     def get_by_code(self, code: str = None) -> t.Iterator[SkeletonInstance]:
-        query = self.viewSkel().all().filter("scope_code =", code)
+        query = self.viewSkel().all().filter("scope_code.idx =", code.lower())
         for cond_skel in query.fetch(100):
             if cond_skel["is_subcode"]:
                 parent_cond_skel = self.viewSkel()

--- a/src/viur/shop/skeletons/discount_condition.py
+++ b/src/viur/shop/skeletons/discount_condition.py
@@ -1,11 +1,12 @@
 import typing as t  # noqa
 from datetime import datetime as dt
 
-from viur.core import conf
+from viur.core import conf, i18n
 from viur.core.bones import *
 from viur.core.skeleton import Skeleton
 from viur.shop.types import *
 from ..globals import SHOP_LOGGER
+from ..modules.discount_condition import CODE_CHARS
 
 logger = SHOP_LOGGER.getChild(__name__)
 
@@ -112,19 +113,32 @@ class DiscountConditionSkel(Skeleton):  # STATE: Complete (as in model)
     )
 
     scope_code = StringBone(
-        # TODO: limit charset
+        # TODO: limit charset on server side
         params={
             "category": "2 – Scope",
-            "visibleIf": 'code_type == "universal"'
+            "visibleIf": 'code_type == "universal"',
+            "pattern": rf'^[{"".join(CODE_CHARS)}]+$',
+            "tooltip": BetterTranslate(
+                "viur.shop.skeleton.discountcondition.scope_code.allowed_characters",
+                defaultText="allowed characters: {{chars}}",
+                default_variables=dict(chars="".join(CODE_CHARS))
+            ),
         },
         unique=UniqueValue(UniqueLockMethod.SameValue, False, "Code exist already"),  # TODO
+        caseSensitive=False,
     )
 
     individual_codes_prefix = StringBone(
-        # TODO: limit charset
+        # TODO: limit charset on server side
         params={
             "category": "2 – Scope",
-            "visibleIf": 'code_type == "individual"'
+            "visibleIf": 'code_type == "individual"',
+            "pattern": rf'^[{"".join(CODE_CHARS)}]+$',
+            "tooltip": BetterTranslate(
+                "viur.shop.skeleton.discountcondition.scope_code.allowed_characters",
+                defaultText="allowed characters: {{chars}}",
+                default_variables=dict(chars="".join(CODE_CHARS))
+            ),
         },
         unique=UniqueValue(UniqueLockMethod.SameValue, False, "Value already taken"),
     )

--- a/src/viur/shop/types/__init__.py
+++ b/src/viur/shop/types/__init__.py
@@ -1,6 +1,7 @@
 import typing as t
 
 from viur.core.skeleton import Skeleton as _Skeleton, SkeletonInstance as _SkeletonInstance
+from ...core import i18n
 
 SkeletonCls_co = t.TypeVar("SkeletonCls_co", bound=t.Type[_Skeleton], covariant=True)
 
@@ -51,3 +52,20 @@ from .exceptions import (  # noqa
 from .price import Price  # noqa
 from .response import ExtendedCustomJsonEncoder, JsonResponse  # noqa
 from .results import (OrderViewResult, PaymentProviderResult, StatusError)  # noqa
+
+
+class BetterTranslate(i18n.translate):
+    """Extent :class:`i18n.translate` with ``default_variables``.
+
+    Should be part of standard: https://github.com/viur-framework/viur-core/issues/1379
+    """
+
+    def __init__(self, *args, default_variables: dict[str, str] | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.default_variables = default_variables or {}
+
+    def __str__(self):
+        return self.substitute_vars(super().__str__(), **self.default_variables)
+
+    def translate(self, **kwargs) -> str:
+        return self.substitute_vars(str(self), **(self.default_variables | kwargs))

--- a/src/viur/shop/types/dc_scope.py
+++ b/src/viur/shop/types/dc_scope.py
@@ -205,7 +205,7 @@ class ScopeCode(DiscountConditionScope):
         ):
             # logger.info(f'scope_code UNIVERSAL not reached ({self.condition_skel["scope_code"]=} != {self.code=})')
             logger.debug(f'scope_code {self.condition_skel["scope_code"]=} =?= {self.code=}')
-            return self.condition_skel["scope_code"] == self.code
+            return self.condition_skel["scope_code"].lower() == self.code.lower()
         elif (
             self.condition_skel["code_type"] == CodeType.INDIVIDUAL
         ):


### PR DESCRIPTION
discount codes writing does no longer matter "myvoucher" is now equal to "MYVOUCHER" and "MyVoucHEr".

**BUT** note; This limits also the entropy for subcodes