### PR TITLE
feat: Implement `shop_view_url`

### DIFF
--- a/src/viur/shop/skeletons/article.py
+++ b/src/viur/shop/skeletons/article.py
@@ -2,8 +2,10 @@ import abc
 import inspect
 import typing as t  # noqa
 
+from viur.core import utils
 from viur.core.bones import *
 from viur.core.skeleton import BaseSkeleton
+
 from viur.shop.types import *
 from ..globals import SHOP_INSTANCE, SHOP_LOGGER
 from ..types.response import make_json_dumpable
@@ -84,6 +86,15 @@ class ArticleAbstractSkel(BaseSkeleton):
     def shop_is_low_price(self) -> BooleanBone:
         """shop_price_retail != shop_price_recommended"""
         ...
+
+    shop_view_url = RawBone(
+        visible=False,
+        compute=Compute(
+            lambda skel: utils.seoUrlToEntry(skel.kindName, skel),
+            ComputeInterval(ComputeMethod.Always),
+        ),
+    )
+    """URL to the article page (view)"""
 
     @property
     def shop_price_(self) -> Price:

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -246,13 +246,6 @@ class CartItemSkel(TreeSkel):  # STATE: Complete (as in model)
         # FIXME: What's necessary here?
         parentKeys=["key", "parententry", "article"],
         refKeys=[
-            "shop_name", "shop_description",
-            "shop_price_retail", "shop_price_recommended",
-            "shop_availability", "shop_listed",
-            "shop_image", "shop_art_no_or_gtin",
-            "shop_vat", "shop_shipping_config",
-            "shop_is_weee", "shop_is_low_price",
-            "shop_price_current",
             "shop_*",
         ],
         consistency=RelationalConsistency.CascadeDeletion,


### PR DESCRIPTION
This URL is required for the shop components to create a link to article in the cart

Note: core's `seoUrlToEntry` method has sadly currently some problems and may not work correctly.