### PR TITLE
feat: Delete orphaned carts

### DIFF
--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -673,6 +673,7 @@ class Cart(ShopModuleAbstract, Tree):
 
 @Session.on_delete
 def delete_guest_cart(session: db.Entity) -> None:
+    """Delete carts from guest sessions to avoid orphaned carts"""
     if session["user"] != Session.GUEST_USER:
         return
     try:

--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -671,6 +671,15 @@ class Cart(ShopModuleAbstract, Tree):
         return new_parent_skel
 
 
+try:
+    Session.on_delete
+except AttributeError:  # backward compatibility for viur-core
+    from viur.core.version import __version__
+
+    logger.warning(f"viur-core {__version__} has no Session.on_delete")
+    Session.on_delete = lambda *_, **__: None
+
+
 @Session.on_delete
 def delete_guest_cart(session: db.Entity) -> None:
     """Delete carts from guest sessions to avoid orphaned carts"""


### PR DESCRIPTION
After guest sessions has been deleted the session cart can be deleted too.

This feature requires https://github.com/viur-framework/viur-core/pull/1438

Resolves #1 
