### PR TITLE
feat: Create basket lazy

### DIFF
--- a/src/viur/shop/modules/api.py
+++ b/src/viur/shop/modules/api.py
@@ -51,7 +51,15 @@ class Api(ShopModuleAbstract):
         parent_cart_key: str | db.Key | t.Literal["BASKET"] = SENTINEL,
         **kwargs,
     ):
-        """Add an article to the cart"""
+        """Add an article to the cart
+
+        :param article_key: Key of the article to add.
+        :param quantity: Quantity of the article to add.
+        :param quantity_mode: Behavior of the quantity: absolute or relative valuation
+        :param parent_cart_key: Key of the (sub) cart (node) to which
+            this leaf will be added as a child.
+            Use "BASKET" as key to use the basket of the current session.
+        """
         article_key = self._normalize_external_key(
             article_key, "article_key")
         if parent_cart_key == "BASKET":
@@ -78,7 +86,16 @@ class Api(ShopModuleAbstract):
         parent_cart_key: str | db.Key | t.Literal["BASKET"] = SENTINEL,
         **kwargs,
     ):
-        """Update an existing article in the cart"""
+        """Update an existing article in the cart
+
+        :param article_key: Key of the article to update.
+            Note: This is not the key of the leaf skel!
+        :param quantity: Quantity of the article to update.
+        :param quantity_mode: Behavior of the quantity: absolute or relative valuation
+        :param parent_cart_key: Optional. Key of the (sub) cart (node) to which
+            this leaf will be moved to as a child.
+            Use "BASKET" as key to use the basket of the current session.
+        """
         article_key = self._normalize_external_key(
             article_key, "article_key")
         if parent_cart_key == "BASKET":

--- a/src/viur/shop/modules/api.py
+++ b/src/viur/shop/modules/api.py
@@ -541,6 +541,8 @@ class Api(ShopModuleAbstract):
             return None
         elif not external_key:
             raise InvalidKeyException(external_key, parameter_name)
+        if isinstance(external_key, db.Key):
+            return external_key
         try:
             return db.Key.from_legacy_urlsafe(external_key)
         except (ValueError, DecodeError):  # yes, the exception really comes from protobuf...

--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -58,7 +58,7 @@ class Cart(ShopModuleAbstract, Tree):
 
     @property
     def current_session_cart_key(self) -> db.Key | None:
-        return self.get_current_session_cart_key()
+        return self.get_current_session_cart_key(create_if_missing=False)
 
     def get_current_session_cart_key(self, *, create_if_missing: bool = False) -> db.Key | None:
         if user := current.user.get():

--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -1,12 +1,11 @@
 import typing as t  # noqa
 
+import viur.shop.types.exceptions as e
 from viur.core import conf, current, db, errors, exposed, utils
 from viur.core.bones import BaseBone
 from viur.core.prototypes import Tree
 from viur.core.prototypes.tree import SkelType
 from viur.core.skeleton import Skeleton, SkeletonInstance
-
-import viur.shop.types.exceptions as e
 from viur.shop.modules.abstract import ShopModuleAbstract
 from viur.shop.types import *
 from viur.shop.types.exceptions import InvalidStateError
@@ -58,32 +57,35 @@ class Cart(ShopModuleAbstract, Tree):
     # --- Session -------------------------------------------------------------
 
     @property
-    def current_session_cart_key(self):
+    def current_session_cart_key(self) -> db.Key | None:
+        return self.get_current_session_cart_key()
+
+    def get_current_session_cart_key(self, *, create_if_missing: bool = False) -> db.Key | None:
         if user := current.user.get():
             user_skel = conf.main_app.vi.user.viewSkel()
             user_skel.fromDB(user["key"])
             if user_skel["basket"]:
                 self.session["session_cart_key"] = user_skel["basket"]["dest"]["key"]
                 current.session.get().markChanged()
-        self._ensure_current_session_cart()
+        if create_if_missing:
+            self._ensure_current_session_cart()
         return self.session.get("session_cart_key")
 
     @property
-    def current_session_cart(self):  # TODO: Caching
+    def current_session_cart(self) -> SkeletonInstance_T[CartNodeSkel]:  # TODO: Caching
         skel = self.viewSkel("node")
-        if not skel.fromDB(self.current_session_cart_key):
+        if not skel.fromDB(self.get_current_session_cart_key(create_if_missing=True)):
             logger.critical(f"Invalid session_cart_key {self.current_session_cart_key} ?! Not in DB!")
             self.detach_session_cart()
             return self.current_session_cart
             raise InvalidStateError(f"Invalid session_cart_key {self.current_session_cart_key} ?! Not in DB!")
-        return skel
+        return skel  # type: ignore
 
-    def _ensure_current_session_cart(self):
+    def _ensure_current_session_cart(self) -> db.Key:
         if not self.session.get("session_cart_key"):
             root_node = self.addSkel("node")
-            user = current.user.get() and current.user.get()["name"] or "__guest__"
             root_node["is_root_node"] = True
-            root_node["name"] = f"Session Cart of {user} created at {utils.utcNow()}"
+            root_node["name"] = root_node.name.getDefaultValue(root_node)
             root_node["cart_type"] = CartType.BASKET
             key = root_node.toDB()
             self.session["session_cart_key"] = key
@@ -110,7 +112,9 @@ class Cart(ShopModuleAbstract, Tree):
         return user_skel
 
     def get_available_root_nodes(self, *args, **kwargs) -> list[dict[t.Literal["name", "key"], str]]:
-        root_nodes = [self.current_session_cart]
+        root_nodes = []
+        if self.current_session_cart_key is not None:
+            root_nodes.append(self.current_session_cart)
 
         if user := current.user.get():
             for wishlist in user["wishlist"]:

--- a/src/viur/shop/modules/discount.py
+++ b/src/viur/shop/modules/discount.py
@@ -79,6 +79,8 @@ class Discount(ShopModuleAbstract, List):
         if not bool(code) ^ bool(discount_key):
             raise ValueError(f"Need code xor discount_code")
         cart_key = self.shop.cart.current_session_cart_key  # TODO: parameter?
+        if cart_key is None:
+            raise errors.PreconditionFailed("No basket created yet for this session")
 
         skels = self.search(code, discount_key)
         # logger.debug(f"{skels = }")

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -1,12 +1,11 @@
 import collections
 import typing as t  # noqa
 
-from viur.core import db
+from viur import toolkit
+from viur.core import current, db, utils
 from viur.core.bones import *
 from viur.core.prototypes.tree import TreeSkel
 from viur.core.skeleton import SkeletonInstance
-
-from viur import toolkit
 from viur.shop.types import *
 from .vat import VatIncludedSkel
 from ..globals import SHOP_INSTANCE, SHOP_LOGGER
@@ -196,6 +195,10 @@ class CartNodeSkel(TreeSkel):  # STATE: Complete (as in model)
     )
 
     name = StringBone(
+        defaultValue=lambda skel, bone: (
+            f"Session Cart of {current.user.get() and current.user.get()["name"] or "__guest__"}"
+            f" created at {utils.utcNow()}"
+        )
     )
 
     cart_type = SelectBone(


### PR DESCRIPTION
Instead of creating a basket always this PR changes the behavior to a lazy creation. The basket will from now on only created on `article_add` or if `basket_view` oder `get_current_session_cart_key` has been explicit called with `create_if_missing=True`.