### PR TITLE
chore: Enforce `viur-core >= 3.7`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,10 @@ build-backend = "setuptools.build_meta"
 name = "viur-shop"
 dynamic = ["version"]
 dependencies = [
-    "viur-toolkit>=0.1.0.dev4"
+    "viur-toolkit>=0.2.0",
+    "viur-core>=3.7.0"
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     { name = "Sven Eberth", email = "se@mausbrand.de" },
 ]
@@ -23,11 +24,10 @@ readme = "README.md"
 license = { file = "LICENSE" }
 keywords = ["viur", "plugin", "backend", "shop"]
 classifiers = [
-    "Development Status :: 1 - Planning",
+    "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/src/viur/shop/modules/address.py
+++ b/src/viur/shop/modules/address.py
@@ -82,7 +82,7 @@ class Address(ShopModuleAbstract, List):
         for other_skel in query.fetch(100):
             if skel["key"] != other_skel["key"]:
                 other_skel["is_default"] = False
-                other_skel.toDB()
+                other_skel.write()
 
 
 Address.json = True

--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -85,8 +85,8 @@ class Cart(ShopModuleAbstract, Tree):
             root_node["is_root_node"] = True
             root_node["name"] = f"Session Cart of {user} created at {utils.utcNow()}"
             root_node["cart_type"] = CartType.BASKET
-            key = root_node.write()
-            self.session["session_cart_key"] = key
+            root_node.write()
+            self.session["session_cart_key"] = root_node["key"]
             current.session.get().markChanged()
             # Store basket at the user skel, it will be shared over multiple sessions / devices
             if user := current.user.get():
@@ -333,7 +333,7 @@ class Cart(ShopModuleAbstract, Tree):
                 descr_appendix=f'Quantity of free article cannot be greater than 1! (reached {skel["quantity"]})'
             )
         skel = self.additional_add_or_update_article(skel, **kwargs)
-        key = skel.write()
+        skel.write()
         EVENT_SERVICE.call(Event.ARTICLE_CHANGED, skel=skel, deleted=False)
         self.clear_children_cache()
         # TODO: Validate quantity with hook (stock availability)

--- a/src/viur/shop/modules/discount.py
+++ b/src/viur/shop/modules/discount.py
@@ -51,7 +51,7 @@ class Discount(ShopModuleAbstract, List):
 
         skel = self.viewSkel()
         if discount_key is not None:
-            if not skel.fromDB(discount_key):
+            if not skel.read(discount_key):
                 raise errors.NotFound
             return [skel]
         elif code is not None:
@@ -152,7 +152,7 @@ class Discount(ShopModuleAbstract, List):
                     for leaf_skel in leaf_skels:
                         # Assign discount on new parent node for the leaf where the article is
                         parent_skel = self.shop.cart.viewSkel("node")
-                        assert parent_skel.fromDB(leaf_skel["parententry"])
+                        assert parent_skel.read(leaf_skel["parententry"])
                         if parent_skel["discount"] and parent_skel["discount"]["dest"]["key"] == discount_skel["key"]:
                             logger.info("Parent has already this discount key")
                             continue
@@ -189,7 +189,7 @@ class Discount(ShopModuleAbstract, List):
             cart = None
         else:
             cart = self.shop.cart.viewSkel("node")
-            if not cart.fromDB(cart_key):
+            if not cart.read(cart_key):
                 raise errors.NotFound
 
         if not as_automatically and skel["activate_automatically"]:
@@ -224,7 +224,7 @@ class Discount(ShopModuleAbstract, List):
 
         discount_skel = self.viewSkel()
 
-        if not discount_skel.fromDB(discount_key):
+        if not discount_skel.read(discount_key):
             raise errors.NotFound
         try:
             # Todo what we do when we have more than more condition

--- a/src/viur/shop/modules/discount_condition.py
+++ b/src/viur/shop/modules/discount_condition.py
@@ -100,7 +100,7 @@ class DiscountCondition(ShopModuleAbstract, List):
         # logger.debug(pprint.pformat(skel, width=120))
         skel_old = self.viewSkel()
         if skel["key"] is not None:  # not on add
-            skel_old.fromDB(skel["key"])
+            skel_old.read(skel["key"])
         current.request_data.get()[f'shop_skel_{skel["key"]}'] = skel_old
 
     def on_changed(self, skel, event: str):
@@ -119,7 +119,7 @@ class DiscountCondition(ShopModuleAbstract, List):
         """Generate subcodes for a parent individual code."""
         chunk_amount = amount
         while chunk_amount > 0:
-            skel = self.addSkel()  # .subSkel("individual")
+            skel = self.addSkel()  # .subskel("individual")
             skel["is_subcode"] = True
             skel["quantity_volume"] = 1
             skel.setBoneValue("parent_code", parent_key)
@@ -131,7 +131,7 @@ class DiscountCondition(ShopModuleAbstract, List):
 
                 try:
                     self.onAdd(skel)
-                    skel.toDB()
+                    skel.write()
                     self.onAdded(skel)
                     break
                 except ValueError as e:
@@ -164,7 +164,7 @@ class DiscountCondition(ShopModuleAbstract, List):
     def _get_skel(key: db.Key, ttl_hash: int | None = None) -> SkeletonInstance_T["DiscountConditionSkel"] | None:
         # logger.debug(f"_get_skel({key=}, {ttl_hash=})")
         skel = SHOP_INSTANCE.get().discount_condition.viewSkel()
-        if not skel.fromDB(key):
+        if not skel.read(key):
             return None
         return skel  # type: ignore
 
@@ -175,7 +175,7 @@ class DiscountCondition(ShopModuleAbstract, List):
         for cond_skel in query.fetch(100):
             if cond_skel["is_subcode"]:
                 parent_cond_skel = self.viewSkel()
-                assert parent_cond_skel.fromDB(cond_skel["parent_code"]["dest"]["key"])
+                assert parent_cond_skel.read(cond_skel["parent_code"]["dest"]["key"])
                 yield parent_cond_skel
                 # yield cond_skel["parent_code"]["dest"]
             else:
@@ -202,7 +202,7 @@ class DiscountCondition(ShopModuleAbstract, List):
 
         for discount in discounts:
             d_skel = self.shop.discount.viewSkel()
-            d_skel.fromDB(discount)
+            d_skel.read(discount)
             for condition in d_skel["condition"]:
                 # TODO: Increase only "active" conditions in case of OR operator
                 # cond_skel = toolkit.get_full_skel_from_ref_skel(condition["dest"])

--- a/src/viur/shop/modules/order.py
+++ b/src/viur/shop/modules/order.py
@@ -364,7 +364,7 @@ class Order(ShopModuleAbstract, List):
             ba_skel[name] = value
         ba_skel.setBoneValue("cloned_from", ba_key)
         # logger.debug(f"{order_skel = }")
-        key = ba_skel.write()
+        ba_skel.write()
         # logger.debug(f"{key = } // {ba_skel = }")
         assert ba_skel["key"] != ba_key, \
             f'{ba_skel["key"]} != {ba_key}'

--- a/src/viur/shop/modules/shipping.py
+++ b/src/viur/shop/modules/shipping.py
@@ -77,7 +77,7 @@ class Shipping(ShopModuleAbstract, List):
         :return: A list of :class:`SkeletonInstance`s for the :class:`ShippingSkel`.
         """
         cart_skel = self.shop.cart.viewSkel("node")
-        if not cart_skel.fromDB(cart_key):
+        if not cart_skel.read(cart_key):
             raise errors.NotFound
 
         all_shipping_configs: list[RefSkel] = []

--- a/src/viur/shop/payment_providers/unzer_abstract.py
+++ b/src/viur/shop/payment_providers/unzer_abstract.py
@@ -179,7 +179,7 @@ class UnzerAbstract(PaymentProviderAbstract):
     ) -> t.Any:
         order_key = self.shop.api._normalize_external_key(order_key, "order_key")
         order_skel = self.shop.order.viewSkel()
-        if not order_skel.fromDB(order_key):
+        if not order_skel.read(order_key):
             raise errors.NotFound
         is_paid, payment = self.check_payment_state(order_skel)
         charges = payment.getChargedTransactions()
@@ -209,7 +209,7 @@ class UnzerAbstract(PaymentProviderAbstract):
     ):
         order_key = self.shop.api._normalize_external_key(order_key, "order_key")
         order_skel = self.shop.order.editSkel()
-        if not order_skel.fromDB(order_key):
+        if not order_skel.read(order_key):
             raise errors.NotFound
 
         order_skel = self._append_payment_to_order_skel(

--- a/src/viur/shop/services/hooks.py
+++ b/src/viur/shop/services/hooks.py
@@ -33,19 +33,19 @@ class Hook(enum.IntEnum):
 
     ORDER_ADD_ADDITION = enum.auto()
     """Do some additional modifications on the OrderSkel on order_add action.
-    Called in :meth:`viur.shop.modules.order.Order.order_add` before saving with :meth:`Skeleton.toDB`.
+    Called in :meth:`viur.shop.modules.order.Order.order_add` before saving with :meth:`Skeleton.write`.
     type: (order_skel: SkeletonInstance_T[OrderSkel]) -> SkeletonInstance_T[OrderSkel]
     """
 
     ORDER_UPDATE_ADDITION = enum.auto()
     """Do some additional modifications on the OrderSkel on order_update action.
-    Called in :meth:`viur.shop.modules.order.Order.order_update` before saving with :meth:`Skeleton.toDB`.
+    Called in :meth:`viur.shop.modules.order.Order.order_update` before saving with :meth:`Skeleton.write`.
     type: (order_skel: SkeletonInstance_T[OrderSkel]) -> SkeletonInstance_T[OrderSkel]
     """
 
     ORDER_CHECKOUT_START_ADDITION = enum.auto()
     """Do some additional modifications on the OrderSkel on checkout_start action.
-    Called in :meth:`viur.shop.modules.order.Order.checkout_start` before saving with :meth:`Skeleton.toDB`.
+    Called in :meth:`viur.shop.modules.order.Order.checkout_start` before saving with :meth:`Skeleton.write`.
     type: (order_skel: SkeletonInstance_T[OrderSkel]) -> SkeletonInstance_T[OrderSkel]
     """
 

--- a/src/viur/shop/shop.py
+++ b/src/viur/shop/shop.py
@@ -217,7 +217,7 @@ class Shop(InstancedModule, Module):
                     logger.info(f"Update existing translation {key}")
                     logger.debug(f'{old_translations} --> {skel["translations"], skel["default_text"], skel["hint"]}')
                     try:
-                        skel.toDB()
+                        skel.write()
                     except Exception as exc:
                         logger.exception(f"Failed to write updated translation {skel=} :: {exc}")
                 continue
@@ -230,7 +230,7 @@ class Shop(InstancedModule, Module):
             skel["creator"] = Creator.VIUR
             skel["public"] = True
             try:
-                skel.toDB()
+                skel.write()
             except Exception as exc:
                 logger.exception(f"Failed to write added translation {skel=} :: {exc}")
 

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -1,12 +1,11 @@
 import collections
 import typing as t  # noqa
 
+from viur import toolkit
 from viur.core import db
 from viur.core.bones import *
 from viur.core.prototypes.tree import TreeSkel
 from viur.core.skeleton import SkeletonInstance
-
-from viur import toolkit
 from viur.shop.types import *
 from .vat import VatIncludedSkel
 from ..globals import SHOP_INSTANCE, SHOP_LOGGER
@@ -341,7 +340,3 @@ class CartItemSkel(TreeSkel):  # STATE: Complete (as in model)
             ComputeInterval(ComputeMethod.Always)),
     )
     shipping.type = JsonBone.type
-
-    @classmethod
-    def write(cls, skelValues: SkeletonInstance, update_relations: bool = True, **kwargs) -> db.Key:
-        return super().write(skelValues, update_relations, **kwargs)

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -313,7 +313,7 @@ class CartItemSkel(TreeSkel):  # STATE: Complete (as in model)
         # TODO: Cache this property
         # logger.debug(f'Reading article_skel_full {self.article_skel["key"]=}')
         skel = SHOP_INSTANCE.get().article_skel()
-        assert skel.fromDB(self.article_skel["key"])
+        assert skel.read(self.article_skel["key"])
         return skel
 
     @property
@@ -321,7 +321,7 @@ class CartItemSkel(TreeSkel):  # STATE: Complete (as in model)
         if not (pk := self["parententry"]):
             return None
         skel = SHOP_INSTANCE.get().cart.viewSkel("node")
-        assert skel.fromDB(pk)
+        assert skel.read(pk)
         return skel
 
     @property
@@ -343,5 +343,5 @@ class CartItemSkel(TreeSkel):  # STATE: Complete (as in model)
     shipping.type = JsonBone.type
 
     @classmethod
-    def toDB(cls, skelValues: SkeletonInstance, update_relations: bool = True, **kwargs) -> db.Key:
-        return super().toDB(skelValues, update_relations, **kwargs)
+    def write(cls, skelValues: SkeletonInstance, update_relations: bool = True, **kwargs) -> db.Key:
+        return super().write(skelValues, update_relations, **kwargs)

--- a/src/viur/shop/skeletons/shipping_config.py
+++ b/src/viur/shop/skeletons/shipping_config.py
@@ -32,9 +32,9 @@ class ShippingConfigSkel(Skeleton):  # STATE: Complete (as in model)
     )
 
     @classmethod
-    def fromDB(cls, skel: SkeletonInstance, key: db.Key | int | str) -> bool:
+    def read(cls, skel: SkeletonInstance, key: db.Key | int | str) -> bool:
         # Migration after renaming
-        res = super().fromDB(skel, key)
+        res = super().read(skel, key)
         if not skel.dbEntity.get("shipping"):
             skel.dbEntity["shipping"] = skel.dbEntity.get("shipping_skel")
         return res

--- a/src/viur/shop/skeletons/shipping_config.py
+++ b/src/viur/shop/skeletons/shipping_config.py
@@ -32,9 +32,9 @@ class ShippingConfigSkel(Skeleton):  # STATE: Complete (as in model)
     )
 
     @classmethod
-    def read(cls, skel: SkeletonInstance, key: db.Key | int | str) -> bool:
+    def read(cls, skel: SkeletonInstance, *args, **kwargs) -> bool:
         # Migration after renaming
-        res = super().read(skel, key)
+        res = super().read(skel, *args, **kwargs)
         if not skel.dbEntity.get("shipping"):
             skel.dbEntity["shipping"] = skel.dbEntity.get("shipping_skel")
         return res


### PR DESCRIPTION
This allows to use only the newer `.read()` and `.write()` syntax and newer features