### PR TITLE
feat: Implement `refresh_cart` in `OrderSkel`

### DIFF
--- a/src/viur/shop/modules/order.py
+++ b/src/viur/shop/modules/order.py
@@ -2,10 +2,9 @@ import logging
 import time
 import typing as t  # noqa
 
+from viur import toolkit
 from viur.core import current, db, errors as core_errors, exposed, force_post
 from viur.core.prototypes import List
-
-from viur import toolkit
 from viur.shop.types import *
 from viur.shop.types.results import PaymentProviderResult
 from .abstract import ShopModuleAbstract
@@ -114,7 +113,6 @@ class Order(ShopModuleAbstract, List):
         if not self.canView(skel):
             logger.debug(f"Order {order_key} is forbidden by canView")
             return None
-        skel.refresh()  # TODO: cart.shipping_address relation seems not be updated by the core
         return skel
 
     def order_add(
@@ -203,6 +201,7 @@ class Order(ShopModuleAbstract, List):
         except DispatchError:
             pass
         skel = self.additional_order_update(skel, **kwargs)
+        OrderSkel.refresh_cart(skel)
         self.onEdit(skel)
         skel.write()
         self.onEdited(skel)

--- a/src/viur/shop/payment_providers/unzer_abstract.py
+++ b/src/viur/shop/payment_providers/unzer_abstract.py
@@ -191,7 +191,7 @@ class UnzerAbstract(PaymentProviderAbstract):
             self.shop.order.set_paid(order_skel)
         else:
             raise errors.NotImplemented("Order not paid")
-        return "OKAY, paid"
+        return "OKAY, paid"  # TODO
 
     @exposed
     def webhook(self):

--- a/src/viur/shop/skeletons/order.py
+++ b/src/viur/shop/skeletons/order.py
@@ -136,7 +136,7 @@ class OrderSkel(Skeleton):  # STATE: Complete (as in model)
         try:
             skel.cart.refresh(skel, skel.cart.name)
         except Exception as exc:
-            logger.debug(f"Failed to refresh cart on order {skel["key"]!r}: {exc}")
+            logger.debug(f'Failed to refresh cart on order {skel["key"]!r}: {exc}')
         return skel
 
     @classmethod

--- a/src/viur/shop/skeletons/order.py
+++ b/src/viur/shop/skeletons/order.py
@@ -2,7 +2,7 @@ import typing as t  # noqa
 
 from viur.core import translate
 from viur.core.bones import *
-from viur.core.skeleton import Skeleton
+from viur.core.skeleton import Skeleton, SkeletonInstance
 from viur.shop.types import *
 from ..globals import SHOP_INSTANCE, SHOP_LOGGER
 
@@ -125,3 +125,22 @@ class OrderSkel(Skeleton):  # STATE: Complete (as in model)
     payment = JsonBone(
         defaultValue=lambda skel, self: {},
     )
+
+    @classmethod
+    def refresh_cart(cls, skel: SkeletonInstance) -> SkeletonInstance:
+        """
+        Shorthand to refresh the cart of an OrderSkel
+        Due to race-condition and timing issues, the dest values are not always
+        set correctly. This refresh fixes this.
+        """
+        try:
+            skel.cart.refresh(skel, skel.cart.name)
+        except Exception as exc:
+            logger.debug(f"Failed to refresh cart on order {skel["key"]!r}: {exc}")
+        return skel
+
+    @classmethod
+    def read(cls, skel: SkeletonInstance, *args, **kwargs) -> t.Optional[SkeletonInstance]:
+        if res := super().read(skel, *args, **kwargs):
+            cls.refresh_cart(skel)
+        return res


### PR DESCRIPTION
Due to race-condition and timing issues, the dest values are not always set correctly. This refresh fixes this.