### PR TITLE
fix: Show only shipping with special zip code

### DIFF
--- a/src/viur/shop/modules/shipping.py
+++ b/src/viur/shop/modules/shipping.py
@@ -128,6 +128,21 @@ class Shipping(ShopModuleAbstract, List):
             if is_applicable:
                 applicable_shippings.append(shipping)
 
+        # This is a workaround since we does not have a zip_code exclude list. # TODO
+        # If we found any shipping for only the current zip code, we show only shippings with zip_codes.
+        assert cart_skel is not None
+        shipping_address = cart_skel and cart_skel["shipping_address"] and cart_skel["shipping_address"]["dest"]
+        has_zip_shipping = []
+        if shipping_address:
+            for shipping in applicable_shippings:
+                rel = shipping["rel"]
+                if rel["zip_code"] and shipping_address["zip_code"] in rel["zip_code"]:
+                    has_zip_shipping.append(shipping)
+
+        if has_zip_shipping:
+            logger.debug(f"Found {len(has_zip_shipping)} special zip shippings, return only these!")
+            return has_zip_shipping
+
         # logger.debug(f"<{len(applicable_shippings)}>{applicable_shippings=}")
         if not applicable_shippings:
             logger.error("No suitable shipping found")  # TODO: fallback??

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -290,6 +290,25 @@ class CartNodeSkel(TreeSkel):  # STATE: Complete (as in model)
     project_data = JsonBone(
     )
 
+    @classmethod
+    def refresh_shipping_address(cls, skel: SkeletonInstance) -> SkeletonInstance:
+        """
+        Shorthand to refresh the shipping_address of an CartNodeSkel
+        Due to race-condition and timing issues, the dest values are not always
+        set correctly. This refresh fixes this.
+        """
+        try:
+            skel.shipping_address.refresh(skel, skel.shipping_address.name)
+        except Exception as exc:
+            logger.debug(f'Failed to refresh shipping_address on cart {skel["key"]!r}: {exc}')
+        return skel
+
+    @classmethod
+    def read(cls, skel: SkeletonInstance, *args, **kwargs) -> t.Optional[SkeletonInstance]:
+        if res := super().read(skel, *args, **kwargs):
+            cls.refresh_shipping_address(skel)
+        return res
+
 
 class CartItemSkel(TreeSkel):  # STATE: Complete (as in model)
     kindName = "{{viur_shop_modulename}}_cart_leaf"


### PR DESCRIPTION
This is a workaround since we does not have a zip_code exclude list. If we found any shipping for only the current zip code, we show only shippings with zip_codes.