### PR TITLE
fix: Use custom `GlobalVar` implementation to store globals

### DIFF
--- a/src/viur/shop/__init__.py
+++ b/src/viur/shop/__init__.py
@@ -19,6 +19,7 @@ Components included:
     Only a single shop instance per project is currently supported.
 """
 
+from .types_global import *
 from .globals import *
 from .modules import *
 from .payment_providers import *

--- a/src/viur/shop/globals.py
+++ b/src/viur/shop/globals.py
@@ -1,25 +1,22 @@
 import logging
 import typing as t
-from contextvars import ContextVar
+
+from .types_global import GlobalVar, Sentinel
 
 if t.TYPE_CHECKING:
     from .shop import Shop
 
 SHOP_LOGGER: logging.Logger = logging.getLogger("viur.shop")
+"""viur-shop base logger instance"""
 
-SHOP_INSTANCE: ContextVar["Shop"] = ContextVar("ShopInstance")
-SHOP_INSTANCE_VI: ContextVar["Shop"] = ContextVar("ShopInstanceVi")
+SHOP_INSTANCE: GlobalVar["Shop"] = GlobalVar("ShopInstance")
+"""The shop instance bound to the default html renderer"""
 
-
-class Sentinel:
-    def __repr__(self) -> str:
-        return "<SENTINEL>"
-
-    def __bool__(self) -> bool:
-        return False
-
+SHOP_INSTANCE_VI: GlobalVar["Shop"] = GlobalVar("ShopInstanceVi")
+"""The shop instance bound to the vi renderer"""
 
 SENTINEL: t.Final[Sentinel] = Sentinel()
+"""Unique sentinel object used to detect if a value was explicitly set or not"""
 
-DEBUG_DISCOUNTS = ContextVar("DEBUG_DISCOUNTS", default=False)
+DEBUG_DISCOUNTS: GlobalVar[bool] = GlobalVar("DEBUG_DISCOUNTS", default=False)
 """Print detailed discount evaluation for debugging"""

--- a/src/viur/shop/types_global/__init__.py
+++ b/src/viur/shop/types_global/__init__.py
@@ -1,0 +1,2 @@
+from .global_var import GlobalVar  # noqa
+from .sentinel import Sentinel  # noqa

--- a/src/viur/shop/types_global/global_var.py
+++ b/src/viur/shop/types_global/global_var.py
@@ -1,0 +1,65 @@
+import typing as t
+
+from .sentinel import Sentinel
+
+_T = t.TypeVar("_T")
+"""The generic type of the value stored in the GlobalVar"""
+
+_SENTINEL: t.Final[Sentinel] = Sentinel()
+"""Unique sentinel object used to detect if a value was explicitly set or not"""
+
+
+class GlobalVar(t.Generic[_T]):
+    """
+    A generic container for storing a global-like variable with optional default fallback.
+
+    This class allows safe setting and retrieval of values, with
+    optional fallbacks and error handling if no value is set.
+    """
+
+    __slots__ = ("name", "value")
+
+    def __init__(self, name: str, default: _T = _SENTINEL):
+        """
+        Initialize a GlobalVar instance.
+
+        :param name: The name of the global variable.
+        :param default: Optional default value.
+            If not provided, accessing the value via :meth:`get` will raise a LookupError if unset.
+        """
+        self.name = name
+        self.value = default
+
+    def set(self, value: _T) -> None:
+        """
+        Set the value of the variable.
+
+        :param value: The value to assign to the global variable.
+        """
+        self.value = value
+
+    def get(self, default: _T = _SENTINEL) -> _T:
+        """
+        Retrieve the stored value.
+
+        If no value was explicitly set, returns the provided fallback,
+        or raises a LookupError if neither a value nor fallback exists.
+
+        :param default: Optional fallback value to return if no value is set.
+        :return: The stored value or the provided default.
+        :raises LookupError: If no value is set and no default is provided.
+        """
+        if self.value is not _SENTINEL:
+            return self.value
+        elif default is not _SENTINEL:
+            return default
+        else:
+            raise LookupError(f"<{type(self).__name__} name={self.name!r} at {hex(id(self))}>")
+
+    def __repr__(self) -> str:
+        """
+        Return a string representation of the GlobalVar instance.
+
+        :return: A string representation showing the name and value.
+        """
+        return f"<{type(self).__name__} name={self.name!r} value={self.value!r}>"

--- a/src/viur/shop/types_global/sentinel.py
+++ b/src/viur/shop/types_global/sentinel.py
@@ -1,0 +1,20 @@
+class Sentinel:
+    """
+    A unique sentinel class used as a special marker value.
+
+    An instance of this class can be used to indicate, for example,
+    a unique default value or a special state that is distinct from
+    normal values.
+
+    Attributes
+    ----------
+    - The representation is ``<SENTINEL>`` for improved readability during debugging.
+    - The boolean evaluation is ``False``, so the sentinel behaves as
+      falsey in conditions like ``if sentinel:``.
+    """
+
+    def __repr__(self) -> str:
+        return "<SENTINEL>"
+
+    def __bool__(self) -> bool:
+        return False


### PR DESCRIPTION
`ContextVar` seems to have a different behavior in python 3.13 than in the previous versions. Maybe due to the free-threaded mode. But since we don't need multiple contexts like with asyncio anyway, we can use our own implementation here first and change it to direct assignment later if necessary.

Fixes #142 