### PR TITLE
fix: Adjustments for `viur-core>=3.8.16` due to breaking changes

### DIFF
--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -7,10 +7,11 @@ from viur.core.bones import BaseBone
 from viur.core.prototypes import Tree
 from viur.core.prototypes.tree import SkelType
 from viur.core.session import Session
-from viur.core.skeleton import Skeleton, SkeletonInstance, without_render_preparation
+from viur.core.skeleton import Skeleton, SkeletonInstance
 from viur.shop.modules.abstract import ShopModuleAbstract
 from viur.shop.types import *
 from viur.shop.types.exceptions import InvalidStateError
+
 from ..globals import MAX_FETCH_LIMIT, SENTINEL, SHOP_INSTANCE, SHOP_LOGGER
 from ..services import EVENT_SERVICE, Event
 from ..skeletons.article import ArticleAbstractSkel
@@ -18,6 +19,11 @@ from ..skeletons.cart import CartItemSkel, CartNodeSkel
 from ..types.response import make_json_dumpable
 
 logger = SHOP_LOGGER.getChild(__name__)
+
+if conf.version >= (3, 8, 15):  # TODO: 3,8,16
+    from viur.core.skeleton.utils import without_render_preparation
+else:
+    from viur.toolkit import without_render_preparation
 
 
 class Cart(ShopModuleAbstract, Tree):

--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -11,7 +11,6 @@ from viur.core.skeleton import Skeleton, SkeletonInstance
 from viur.shop.modules.abstract import ShopModuleAbstract
 from viur.shop.types import *
 from viur.shop.types.exceptions import InvalidStateError
-
 from ..globals import MAX_FETCH_LIMIT, SENTINEL, SHOP_INSTANCE, SHOP_LOGGER
 from ..services import EVENT_SERVICE, Event
 from ..skeletons.article import ArticleAbstractSkel
@@ -20,7 +19,7 @@ from ..types.response import make_json_dumpable
 
 logger = SHOP_LOGGER.getChild(__name__)
 
-if conf.version >= (3, 8, 15):  # TODO: 3,8,16
+if conf.version >= (3, 8, 16):
     from viur.core.skeleton.utils import without_render_preparation
 else:
     from viur.toolkit import without_render_preparation

--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -7,7 +7,7 @@ from viur.core.bones import BaseBone
 from viur.core.prototypes import Tree
 from viur.core.prototypes.tree import SkelType
 from viur.core.session import Session
-from viur.core.skeleton import Skeleton, SkeletonInstance
+from viur.core.skeleton import Skeleton, SkeletonInstance, without_render_preparation
 from viur.shop.modules.abstract import ShopModuleAbstract
 from viur.shop.types import *
 from viur.shop.types.exceptions import InvalidStateError
@@ -206,7 +206,7 @@ class Cart(ShopModuleAbstract, Tree):
     ) -> list[SkeletonInstance]:
         cache = current.request_data.get().setdefault("shop_cache_cart_children", {})
         try:
-            return [toolkit.without_render_preparation(s) for s in cache[parent_cart_key]]
+            return [without_render_preparation(s) for s in cache[parent_cart_key]]
         except KeyError:
             pass
         children = list(self.get_children(parent_cart_key))

--- a/src/viur/shop/modules/order.py
+++ b/src/viur/shop/modules/order.py
@@ -414,8 +414,8 @@ class Order(ShopModuleAbstract, List):
         order_skel: "SkeletonInstance",
     ) -> list[ClientError]:
         errors = []
-        # if order_skel["is_ordered"]:
-        #     errors.append(ClientError("already is_ordered"))
+        if order_skel["is_ordered"]:
+            errors.append(ClientError("already is_ordered"))
         if not order_skel["cart"]:
             errors.append(ClientError("cart is missing"))
         if not order_skel["cart"] or not order_skel["cart"]["dest"]["shipping_address"]:
@@ -477,9 +477,6 @@ class Order(ShopModuleAbstract, List):
 
     def set_rts(self, order_skel: "SkeletonInstance") -> "SkeletonInstance":
         """Set an order to the state *Ready to ship*"""
-        logger.debug(f"{order_skel.skeletonCls=}")
-        logger.debug(f"{order_skel.renderPreparation=}")
-        logger.debug(f"{order_skel=}")
         order_skel = toolkit.set_status(
             key=order_skel["key"],
             skel=order_skel,

--- a/src/viur/shop/modules/order.py
+++ b/src/viur/shop/modules/order.py
@@ -414,8 +414,8 @@ class Order(ShopModuleAbstract, List):
         order_skel: "SkeletonInstance",
     ) -> list[ClientError]:
         errors = []
-        if order_skel["is_ordered"]:
-            errors.append(ClientError("already is_ordered"))
+        # if order_skel["is_ordered"]:
+        #     errors.append(ClientError("already is_ordered"))
         if not order_skel["cart"]:
             errors.append(ClientError("cart is missing"))
         if not order_skel["cart"] or not order_skel["cart"]["dest"]["shipping_address"]:
@@ -477,6 +477,9 @@ class Order(ShopModuleAbstract, List):
 
     def set_rts(self, order_skel: "SkeletonInstance") -> "SkeletonInstance":
         """Set an order to the state *Ready to ship*"""
+        logger.debug(f"{order_skel.skeletonCls=}")
+        logger.debug(f"{order_skel.renderPreparation=}")
+        logger.debug(f"{order_skel=}")
         order_skel = toolkit.set_status(
             key=order_skel["key"],
             skel=order_skel,

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -43,6 +43,7 @@ class TotalFactory:
             return SHOP_INSTANCE.get().cart.get_children(parent_cart_key)
 
     def __call__(self, skel: SkeletonInstance_T["CartNodeSkel"], bone: NumericBone):
+        # skel = toolkit.without_render_preparation(skel)
         children = self._get_children(skel["key"])
         total = 0
         for child in children:
@@ -88,14 +89,16 @@ def add_shipping(factory: TotalFactory, total: float, skel: "SkeletonInstance", 
         total += shipping["dest"]["shipping_cost"] or 0.0
     return total
 
-
+@toolkit.debug
 def get_vat_for_node(skel: "CartNodeSkel", bone: RecordBone) -> list[dict]:
+    # skel = toolkit.without_render_preparation(skel)
     children = SHOP_INSTANCE.get().cart.get_children_from_cache(skel["key"])
     cat2value = collections.defaultdict(lambda: 0)
     cat2rate = {}
     # logger.debug(f"{skel=}")
     for child in children:
-        # logger.debug(f"{child=}")
+        logger.debug(f"{child=}")
+        logger.debug(f"{child.renderPreparation=}")
         if issubclass(child.skeletonCls, CartNodeSkel):
             for entry in child["vat"] or []:
                 # logger.debug(f'{child["shop_vat_rate_category"]} | {entry=}')
@@ -107,6 +110,8 @@ def get_vat_for_node(skel: "CartNodeSkel", bone: RecordBone) -> list[dict]:
                 cat2rate[child["shop_vat_rate_category"]] = child.price_.vat_rate_percentage
             except TypeError as e:
                 logger.warning(e)
+        else:
+            raise TypeError(f"Unknown child type: {child.skeletonCls=}")
 
     if shipping := skel["shipping"]:
         try:
@@ -435,7 +440,9 @@ class CartItemSkel(TreeSkel):
         except KeyError:
             # logger.debug(f'Read article_skel_full {self.article_skel["key"]=}')
             skel = SHOP_INSTANCE.get().article_skel()
-            assert skel.read(self.article_skel["key"])
+            res = skel.read(self.article_skel["key"])
+            print(f"skel.read {res=}")
+            assert res
             CartItemSkel.get_article_cache()[self.article_skel["key"]] = skel
             return skel
 

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -15,7 +15,7 @@ from ..types.response import make_json_dumpable
 
 logger = SHOP_LOGGER.getChild(__name__)
 
-if conf.version >= (3, 8, 15):  # TODO: 3,8,16
+if conf.version >= (3, 8, 16):
     from viur.core.skeleton.utils import without_render_preparation
 else:
     from viur.toolkit import without_render_preparation

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -2,17 +2,23 @@ import collections
 import typing as t  # noqa
 
 from viur import toolkit
-from viur.core import current, db, utils
+from viur.core import conf, current, db, utils
 from viur.core.bones import *
 from viur.core.prototypes.tree import TreeSkel
 from viur.core.skeleton import SkeletonInstance
 from viur.shop.types import *
+
 from .vat import VatIncludedSkel
 from ..globals import SHOP_INSTANCE, SHOP_LOGGER
 from ..skeletons.article import ArticleAbstractSkel
 from ..types.response import make_json_dumpable
 
 logger = SHOP_LOGGER.getChild(__name__)
+
+if conf.version >= (3, 8, 15):  # TODO: 3,8,16
+    from viur.core.skeleton.utils import without_render_preparation
+else:
+    from viur.toolkit import without_render_preparation
 
 Addition = t.Callable[["TotalFactory", float, SkeletonInstance_T["CartNodeSkel"], BaseBone], float]
 
@@ -43,7 +49,7 @@ class TotalFactory:
             return SHOP_INSTANCE.get().cart.get_children(parent_cart_key)
 
     def __call__(self, skel: SkeletonInstance_T["CartNodeSkel"], bone: NumericBone):
-        # skel = toolkit.without_render_preparation(skel)
+        skel = without_render_preparation(skel)
         children = self._get_children(skel["key"])
         total = 0
         for child in children:
@@ -89,16 +95,16 @@ def add_shipping(factory: TotalFactory, total: float, skel: "SkeletonInstance", 
         total += shipping["dest"]["shipping_cost"] or 0.0
     return total
 
-@toolkit.debug
+
+# @toolkit.debug
 def get_vat_for_node(skel: "CartNodeSkel", bone: RecordBone) -> list[dict]:
-    # skel = toolkit.without_render_preparation(skel)
+    skel = without_render_preparation(skel)
     children = SHOP_INSTANCE.get().cart.get_children_from_cache(skel["key"])
     cat2value = collections.defaultdict(lambda: 0)
     cat2rate = {}
     # logger.debug(f"{skel=}")
     for child in children:
-        logger.debug(f"{child=}")
-        logger.debug(f"{child.renderPreparation=}")
+        # logger.debug(f"{child=}")
         if issubclass(child.skeletonCls, CartNodeSkel):
             for entry in child["vat"] or []:
                 # logger.debug(f'{child["shop_vat_rate_category"]} | {entry=}')
@@ -441,7 +447,7 @@ class CartItemSkel(TreeSkel):
             # logger.debug(f'Read article_skel_full {self.article_skel["key"]=}')
             skel = SHOP_INSTANCE.get().article_skel()
             res = skel.read(self.article_skel["key"])
-            print(f"skel.read {res=}")
+            logger.info(f"skel.read {res=}")
             assert res
             CartItemSkel.get_article_cache()[self.article_skel["key"]] = skel
             return skel

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -446,9 +446,7 @@ class CartItemSkel(TreeSkel):
         except KeyError:
             # logger.debug(f'Read article_skel_full {self.article_skel["key"]=}')
             skel = SHOP_INSTANCE.get().article_skel()
-            res = skel.read(self.article_skel["key"])
-            logger.info(f"skel.read {res=}")
-            assert res
+            assert skel.read(self.article_skel["key"]) is not None
             CartItemSkel.get_article_cache()[self.article_skel["key"]] = skel
             return skel
 

--- a/src/viur/shop/types/price.py
+++ b/src/viur/shop/types/price.py
@@ -49,7 +49,7 @@ else:
         :param accept_ref_skel: If True, ``obj`` can also be just a RefSkelFor``skel_cls``.
             If False, no ``RefSkel`` is accepted.
         """
-        from . import RefSkel, Skeleton, SkeletonInstance
+        from viur.core.skeleton import RefSkel, Skeleton, SkeletonInstance
 
         if not issubclass(skel_cls, Skeleton):
             raise TypeError(f"{skel_cls=} is not a Skeleton.")

--- a/src/viur/shop/types/price.py
+++ b/src/viur/shop/types/price.py
@@ -21,11 +21,12 @@ import typing as t  # noqa
 
 from viur import toolkit
 from viur.core import current, db, utils
-from viur.core.skeleton import SkeletonInstance
+from viur.core.skeleton import RefSkel, RelSkel, SkeletonInstance
 from .enums import ApplicationDomain, ConditionOperator, DiscountType
 from .exceptions import InvalidStateError
 from ..globals import SHOP_INSTANCE, SHOP_LOGGER
 from ..types import ConfigurationError, DiscountValidationContext
+from viur.core.skeleton.utils import is_skeletoninstance_of
 
 if t.TYPE_CHECKING:
     from ..modules import Discount
@@ -70,7 +71,9 @@ class Price:
         super().__init__()
         # logger.debug(f"Creating new price object based on {src_object=}")
         shop = SHOP_INSTANCE.get()
-        if isinstance(src_object, SkeletonInstance) and issubclass(src_object.skeletonCls, shop.cart.leafSkelCls):
+        if is_skeletoninstance_of(src_object, shop.cart.leafSkelCls):
+        # if isinstance(src_object, SkeletonInstance) and (issubclass(src_object.skeletonCls, shop.cart.leafSkelCls)
+        #     or issubclass(src_object.skeletonCls, RefSkel) and issubclass( src_object.skeletonCls.skeletonCls,shop.cart.leafSkelCls)):
             self.is_in_cart = True
             self.cart_leaf = src_object
             self.article_skel = toolkit.without_render_preparation(src_object.article_skel_full)
@@ -80,10 +83,14 @@ class Price:
                 logger.exception(exc)
                 self.cart_discounts = []
             self.cart_discounts = [toolkit.get_full_skel_from_ref_skel(d) for d in self.cart_discounts]
-        elif isinstance(src_object, SkeletonInstance) and issubclass(src_object.skeletonCls, shop.article_skel):
+        elif is_skeletoninstance_of(src_object, shop.article_skel):
+        # elif isinstance(src_object, SkeletonInstance) and (issubclass(src_object.skeletonCls, shop.article_skel)
+        #     or issubclass(src_object.skeletonCls, RefSkel) and issubclass( src_object.skeletonCls.skeletonCls,shop.article_skel)):
             self.is_in_cart = False
             self.article_skel = toolkit.without_render_preparation(src_object)
         else:
+            logger.error(f"Unsupported type {type(src_object)=} | {src_object.skeletonCls=}")
+            logger.error(f"Unsupported type {type(src_object)=} | {type(src_object.skeletonCls)=}")
             raise TypeError(f"Unsupported type {type(src_object)}")
 
         # logger.debug(f"{self.article_skel = }")

--- a/src/viur/shop/types/price.py
+++ b/src/viur/shop/types/price.py
@@ -20,18 +20,46 @@ import json
 import typing as t  # noqa
 
 from viur import toolkit
-from viur.core import current, db, utils
-from viur.core.skeleton import RefSkel, RelSkel, SkeletonInstance
+from viur.core import conf, current, db, utils
+from viur.core.skeleton import SkeletonInstance
+
 from .enums import ApplicationDomain, ConditionOperator, DiscountType
 from .exceptions import InvalidStateError
 from ..globals import SHOP_INSTANCE, SHOP_LOGGER
 from ..types import ConfigurationError, DiscountValidationContext
-from viur.core.skeleton.utils import is_skeletoninstance_of
 
 if t.TYPE_CHECKING:
     from ..modules import Discount
 
 logger = SHOP_LOGGER.getChild(__name__)
+
+if conf.version >= (3, 8, 15):  # TODO: 3,8,16
+    from viur.core.skeleton.utils import is_skeletoninstance_of
+else:
+    def is_skeletoninstance_of(
+        obj: t.Any,
+        skel_cls: type["Skeleton"],
+        *,
+        accept_ref_skel: bool = True,
+    ) -> bool:
+        """
+        Checks whether an object is an SkeletonInstance that belongs to a specific Skeleton class.
+
+        :param obj: The object to check.
+        :param skel_cls: The skeleton class that will be checked against ``obj``.
+        :param accept_ref_skel: If True, ``obj`` can also be just a RefSkelFor``skel_cls``.
+            If False, no ``RefSkel`` is accepted.
+        """
+        from . import RefSkel, Skeleton, SkeletonInstance
+
+        if not issubclass(skel_cls, Skeleton):
+            raise TypeError(f"{skel_cls=} is not a Skeleton.")
+
+        if not isinstance(obj, SkeletonInstance):
+            return False
+        if issubclass(obj.skeletonCls, skel_cls):
+            return True
+        return False
 
 # TODO: Use decimal package instead of floats?
 #       -> decimal mode in NumericBone?
@@ -72,8 +100,6 @@ class Price:
         # logger.debug(f"Creating new price object based on {src_object=}")
         shop = SHOP_INSTANCE.get()
         if is_skeletoninstance_of(src_object, shop.cart.leafSkelCls):
-        # if isinstance(src_object, SkeletonInstance) and (issubclass(src_object.skeletonCls, shop.cart.leafSkelCls)
-        #     or issubclass(src_object.skeletonCls, RefSkel) and issubclass( src_object.skeletonCls.skeletonCls,shop.cart.leafSkelCls)):
             self.is_in_cart = True
             self.cart_leaf = src_object
             self.article_skel = toolkit.without_render_preparation(src_object.article_skel_full)
@@ -84,13 +110,10 @@ class Price:
                 self.cart_discounts = []
             self.cart_discounts = [toolkit.get_full_skel_from_ref_skel(d) for d in self.cart_discounts]
         elif is_skeletoninstance_of(src_object, shop.article_skel):
-        # elif isinstance(src_object, SkeletonInstance) and (issubclass(src_object.skeletonCls, shop.article_skel)
-        #     or issubclass(src_object.skeletonCls, RefSkel) and issubclass( src_object.skeletonCls.skeletonCls,shop.article_skel)):
             self.is_in_cart = False
             self.article_skel = toolkit.without_render_preparation(src_object)
         else:
             logger.error(f"Unsupported type {type(src_object)=} | {src_object.skeletonCls=}")
-            logger.error(f"Unsupported type {type(src_object)=} | {type(src_object.skeletonCls)=}")
             raise TypeError(f"Unsupported type {type(src_object)}")
 
         # logger.debug(f"{self.article_skel = }")

--- a/src/viur/shop/types/price.py
+++ b/src/viur/shop/types/price.py
@@ -49,7 +49,7 @@ else:
         :param accept_ref_skel: If True, ``obj`` can also be just a RefSkelFor``skel_cls``.
             If False, no ``RefSkel`` is accepted.
         """
-        from viur.core.skeleton import RefSkel, Skeleton, SkeletonInstance
+        from viur.core.skeleton import Skeleton, SkeletonInstance
 
         if not issubclass(skel_cls, Skeleton):
             raise TypeError(f"{skel_cls=} is not a Skeleton.")
@@ -112,8 +112,8 @@ class Price:
             self.is_in_cart = False
             self.article_skel = toolkit.without_render_preparation(src_object)
         else:
-            logger.error(f"Unsupported type {type(src_object)=} | {src_object.skeletonCls=}")
-            raise TypeError(f"Unsupported type {type(src_object)}")
+            logger.error(msg := f"Unsupported type {type(src_object)=} | {getattr(src_object, "skeletonCls", "N/A")=}")
+            raise TypeError(msg)
 
         # logger.debug(f"{self.article_skel = }")
         # logger.debug(f"{self.article_skel.renderPreparation=} | {hex(id(self.article_skel))}")

--- a/src/viur/shop/types/price.py
+++ b/src/viur/shop/types/price.py
@@ -22,7 +22,6 @@ import typing as t  # noqa
 from viur import toolkit
 from viur.core import conf, current, db, utils
 from viur.core.skeleton import SkeletonInstance
-
 from .enums import ApplicationDomain, ConditionOperator, DiscountType
 from .exceptions import InvalidStateError
 from ..globals import SHOP_INSTANCE, SHOP_LOGGER
@@ -33,7 +32,7 @@ if t.TYPE_CHECKING:
 
 logger = SHOP_LOGGER.getChild(__name__)
 
-if conf.version >= (3, 8, 15):  # TODO: 3,8,16
+if conf.version >= (3, 8, 16):
     from viur.core.skeleton.utils import is_skeletoninstance_of
 else:
     def is_skeletoninstance_of(


### PR DESCRIPTION
`viur-core~=3.8` has breaking changes in relational skeleton system and bone computation. Previously, a new, complete skeleton was used each time, without render preparation for `@property`s and compute bones. Now, `SkeletonInstance`s based on `RelSkel`s are reused. This resulted in problems, some of which have already been fixed, but problems also arise in the `viur-shop` due to outdated assumptions. These are being addressed in this PR with a compatibility layer for `viur-core~=3.7.x`.

Requires https://github.com/viur-framework/viur-core/pull/1623 (included in `viur-core==3.8.16`)
or `viur-core~=3.7.x`


This PR was tested with:
* `viur-core==3.7.20`
* `viur-core==3.8.16`

---
 
**Note:** Due to bugs and breaking changes, the stability of the `viur-shop` cannot be guaranteed in `viur-core>=3.8.0<=3.8.15`. However, it is not impossible that it will still work in a few versions. 