### PR TITLE
feat: Remove address cloning

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -28,13 +28,6 @@ indexes:
 
 - kind: shop_address
   properties:
-  - name: cloned_from
-  - name: customer.dest.__key__
-  - name: firstname
-  - name: lastname
-
-- kind: shop_address
-  properties:
   - name: firstname
   - name: lastname
 

--- a/src/viur/shop/data/translations.py
+++ b/src/viur/shop/data/translations.py
@@ -305,11 +305,6 @@ TRANSLATIONS = {
         "en": "City",
         "fr": "Ville",
     },
-    "viur.shop.skeleton.address.cloned_from": {
-        "_hint": "bone cloned_from<RelationalBone> in AddressSkel in viur.shop",
-        "de": "Geklont von",
-        "en": "Cloned from",
-    },
     "viur.shop.skeleton.address.company_name": {
         "_hint": "bone company_name<StringBone> in AddressSkel in viur.shop",
         "de": "Firmenname",

--- a/src/viur/shop/modules/address.py
+++ b/src/viur/shop/modules/address.py
@@ -35,7 +35,6 @@ class Address(ShopModuleAbstract, List):
                 ),
                 "filter": {
                     "customer.dest.key": user["key"],
-                    "cloned_from": "None",
                 },
             })
 
@@ -65,7 +64,6 @@ class Address(ShopModuleAbstract, List):
         # The current customer is only allowed to see his own addresses
         if (user := current.user.get()) and self.render.kind == "json":
             query.filter("customer.dest.__key__ =", user["key"])
-            query.filter("cloned_from =", None)
 
         if user and (f"{self.moduleName}-view" in user["access"] or "root" in user["access"]):
             return query
@@ -92,22 +90,6 @@ class Address(ShopModuleAbstract, List):
             if skel["key"] != other_skel["key"]:
                 other_skel["is_default"] = False
                 other_skel.write()
-
-    def clone_address(self, key: db.Key) -> SkeletonInstance_T[AddressSkel]:
-        # Clone the address, so in case the user edits the address, existing orders wouldn't be affected by this
-        # TODO: Can we do this copy-on-write instead; clone if an address is edited and replace on used order skels?
-        src_address_skel = address_skel = self.editSkel()
-        if not address_skel.read(key):
-            raise ValueError(f"Address with {key=!r} does not exist")
-        # create a new instance and copy all values except the key
-        address_skel = self.shop.address.addSkel()
-        for name, value in src_address_skel.items(True):
-            if name == "key":
-                continue
-            address_skel[name] = value
-        address_skel.setBoneValue("cloned_from", key)
-        address_skel.write()
-        return address_skel
 
 
 Address.json = True

--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -668,16 +668,6 @@ class Cart(ShopModuleAbstract, Tree):
         cart_skel = self.editSkel("node")
         assert cart_skel.read(cart_key)
 
-        # Clone the address, so in case the user edits the address, existing orders wouldn't be affected by this
-        try:
-            sa_key = cart_skel["shipping_address"]["dest"]["key"]
-        except (TypeError, KeyError):  # sub-carts might have no own shipping
-            sa_key = None
-        if sa_key is not None:
-            sa_skel = self.shop.address.clone_address(sa_key)
-            assert sa_skel["key"] != sa_key, f'{sa_skel["key"]} != {sa_key}'
-            cart_skel.setBoneValue("shipping_address", sa_skel["key"])
-
         cart_skel["frozen_values"] = {
             "total": cart_skel["total"],
             "total_raw": cart_skel["total_raw"],

--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -675,6 +675,7 @@ class Cart(ShopModuleAbstract, Tree):
             "vat": cart_skel["vat"],
             "total_quantity": cart_skel["total_quantity"],
             "shipping": cart_skel["shipping"],
+            "shipping_address": cart_skel["shipping_address"]["dest"].dump(),
             "discount": make_json_dumpable(cart_skel["discount"]),
         }
         cart_skel["is_frozen"] = True

--- a/src/viur/shop/modules/order.py
+++ b/src/viur/shop/modules/order.py
@@ -341,13 +341,6 @@ class Order(ShopModuleAbstract, List):
     ) -> SkeletonInstance_T[OrderSkel]:
         cart_skel = self.shop.cart.freeze_cart(order_skel["cart"]["dest"]["key"])
         order_skel["total"] = cart_skel["total_discount_price"]
-
-        # Clone the address, so in case the user edits the address, existing orders wouldn't be affected by this
-        # TODO: Can we do this copy-on-write instead; clone if an address is edited and replace on used order skels?
-        ba_key = order_skel["billing_address"]["dest"]["key"]
-        ba_skel = self.shop.address.clone_address(ba_key)
-        assert ba_skel["key"] != ba_key, f'{ba_skel["key"]} != {ba_key}'
-        order_skel.setBoneValue("billing_address", ba_skel["key"])
         order_skel.write()
         EVENT_SERVICE.call(Event.ORDER_CHANGED, order_skel=order_skel, deleted=False)
 

--- a/src/viur/shop/skeletons/address.py
+++ b/src/viur/shop/skeletons/address.py
@@ -153,10 +153,3 @@ class AddressSkel(Skeleton):
         required=True,
         multiple=True,
     )
-
-    cloned_from = RelationalBone(
-        kind="{{viur_shop_modulename}}_address",
-        module="{{viur_shop_modulename}}/address",
-        readOnly=True,  # set by the system
-        consistency=RelationalConsistency.Ignore,
-    )

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -274,6 +274,8 @@ class CartNodeSkel(TreeSkel):
     shipping_address = RelationalBone(
         kind="{{viur_shop_modulename}}_address",
         module="{{viur_shop_modulename}}/address",
+        # keep shipping address persistent:
+        updateLevel=RelationalUpdateLevel.OnValueAssignment,
         refKeys={
             "*",
         },

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -274,13 +274,9 @@ class CartNodeSkel(TreeSkel):
     shipping_address = RelationalBone(
         kind="{{viur_shop_modulename}}_address",
         module="{{viur_shop_modulename}}/address",
-        refKeys=[
-            "key", "name", "customer_type", "salutation", "company_name",
-            "firstname", "lastname", "street_name", "street_number",
-            "address_addition", "zip_code", "city", "country",
-            "email", "phone",
-            "is_default", "address_type",
-        ],
+        refKeys={
+            "*",
+        },
     )
 
     customer_comment = TextBone(

--- a/src/viur/shop/skeletons/order.py
+++ b/src/viur/shop/skeletons/order.py
@@ -22,15 +22,13 @@ class OrderSkel(Skeleton):
     billing_address = RelationalBone(
         kind="{{viur_shop_modulename}}_address",
         module="{{viur_shop_modulename}}/address",
-        consistency=RelationalConsistency.PreventDeletion,
-        refKeys=[
-            "key", "name", "customer_type", "salutation", "company_name",
-            "firstname", "lastname", "street_name", "street_number",
-            "address_addition", "zip_code", "city", "country",
-            "email", "phone", "birthdate",
-            "is_default", "address_type",
-        ],
         searchable=True,
+        # keep billing address persistent:
+        updateLevel=RelationalUpdateLevel.OnValueAssignment,
+        # keep all fields of the billing address as a copy:
+        refKeys={
+            "*",
+        },
     )
 
     customer = RelationalBone(


### PR DESCRIPTION
Removes the address cloning mechanism that was previously used to snapshot
shipping addresses during order freeze. Instead, address data is now persisted
directly via relational bone configuration.

**Before:** When freezing an order/cart, `clone_address()` created a full copy
of the address record and stored a `cloned_from` back-reference.

**After:** `CartNodeSkel.shipping_address` (and the corresponding bone in
`OrderSkel`) uses `refKeys="*"` with `updateLevel=UpdateLevel.OnValueAssignment`,
capturing the full address at assignment time. Additionally, `shipping_address`
is added to `frozen_values` on `CartNodeSkel` to prevent later mutation.

## Changes

- Remove `clone_address()` method and all call sites in `cart.py` / `order.py`
- Remove `cloned_from` `RelationalBone` from `AddressSkel`
- Set `refKeys="*"` and `updateLevel=UpdateLevel.OnValueAssignment` on shipping
  address bones in cart/order skeletons
- Add `shipping_address` to `CartNodeSkel.frozen_values`
- Drop now-unused `shop_address` Datastore index on `cloned_from`
- Remove `viur.shop.skeleton.address.cloned_from` translation keys
