### PR TITLE
fix: Raise `NotAcceptable` instead of `ValueError` in `order_add`, remove dead `raise` in `current_session_cart`

### DIFF
--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -86,7 +86,6 @@ class Cart(ShopModuleAbstract, Tree):
             logger.critical(f"Invalid session_cart_key {self.current_session_cart_key} ?! Not in DB!")
             self.detach_session_cart()
             return self.current_session_cart
-            raise InvalidStateError(f"Invalid session_cart_key {self.current_session_cart_key} ?! Not in DB!")
         return skel  # type: ignore
 
     def _ensure_current_session_cart(self) -> db.Key:

--- a/src/viur/shop/modules/order.py
+++ b/src/viur/shop/modules/order.py
@@ -135,7 +135,11 @@ class Order(ShopModuleAbstract, List):
         skel = self.addSkel()
         cart_skel = self.shop.cart.viewSkel("node")
         if not self.shop.cart.is_valid_node(cart_key, root_node=True):
-            raise core_errors.NotAcceptable("cart_key is not a valid basket for the current user")
+            raise e.InvalidArgumentException(
+                "cart_key",
+                cart_key,
+                "cart_key is not a valid root cart for the current user",
+            )
         assert cart_skel.read(cart_key)
         skel.setBoneValue("cart", cart_key)
         skel["total"] = cart_skel["total_discount_price"]

--- a/src/viur/shop/modules/order.py
+++ b/src/viur/shop/modules/order.py
@@ -135,7 +135,7 @@ class Order(ShopModuleAbstract, List):
         skel = self.addSkel()
         cart_skel = self.shop.cart.viewSkel("node")
         if not self.shop.cart.is_valid_node(cart_key, root_node=True):
-            raise ValueError(f"Invalid {cart_key=}!")
+            raise core_errors.NotAcceptable("cart_key is not a valid basket for the current user")
         assert cart_skel.read(cart_key)
         skel.setBoneValue("cart", cart_key)
         skel["total"] = cart_skel["total_discount_price"]


### PR DESCRIPTION
- `order_add`: `ValueError` for an invalid `cart_key` resulted in a 500; replaced with `core_errors.NotAcceptable` (406) so the client gets a proper 4xx response it can handle
- `current_session_cart`: the `raise InvalidStateError` after `return self.current_session_cart` was dead code since commit 93b3840; removed the unreachable line