### PR TITLE
fix: Make cart tree navigation tolerant against orphaned entries

### DIFF
--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -10,7 +10,6 @@ from viur.core.session import Session
 from viur.core.skeleton import Skeleton, SkeletonInstance
 from viur.shop.modules.abstract import ShopModuleAbstract
 from viur.shop.types import *
-from viur.shop.types.exceptions import InvalidStateError
 from ..globals import MAX_FETCH_LIMIT, SENTINEL, SHOP_INSTANCE, SHOP_LOGGER
 from ..services import EVENT_SERVICE, Event
 from ..skeletons.article import ArticleAbstractSkel
@@ -706,16 +705,38 @@ class Cart(ShopModuleAbstract, Tree):
         self,
         leaf_key_or_skel: db.Key | SkeletonInstance,
     ) -> list[SkeletonInstance]:
+        """
+        Collect the discounts of all cart nodes above the given leaf.
+
+        Walks the ``parententry`` chain from the leaf up to the root node and
+        collects the ``discount`` relation of every node on the way.
+
+        The walk is tolerant against broken tree data: if a parent node does
+        not exist anymore (orphaned entry) or the chain contains a cycle, the
+        walk stops at the broken link with a warning and the discounts
+        collected so far are returned.  This keeps computed bones (e.g. the
+        price) usable on orphaned entries instead of raising and thereby
+        crashing deferred tasks (like ``update_relations``) forever.
+
+        :param leaf_key_or_skel: Key or skeleton of the cart leaf to start from.
+        :return: The discount ref-skels found on the ancestor nodes.
+        """
         if isinstance(leaf_key_or_skel, db.Key):
             skel = self.viewSkel("leaf")
             skel.read(leaf_key_or_skel)
         else:
             skel = leaf_key_or_skel
         discounts = []
+        seen_keys = set()
         while (pk := skel["parententry"]):
+            if pk in seen_keys:
+                logger.warning(f"Cyclic parententry chain detected at {pk=}; stopping walk")
+                break
+            seen_keys.add(pk)
             skel = self.viewSkel("node", sub_skel="discount")
             if not skel.read(pk):
-                raise InvalidStateError(f"{pk=} doesn't exist!")
+                logger.warning(f"Parent node {pk=} doesn't exist (anymore); stopping walk at orphaned entry")
+                break
             if discount := skel["discount"]:
                 discounts.append(discount["dest"])
         return discounts
@@ -735,14 +756,24 @@ class Cart(ShopModuleAbstract, Tree):
         EVENT_SERVICE.call(Event.ARTICLE_CHANGED, skel=leaf_skel, deleted=False)
         return new_parent_skel
 
-    def get_cached_cart_skel(self, key: db.Key) -> SkeletonInstance_T[CartNodeSkel]:
+    def get_cached_cart_skel(self, key: db.Key) -> SkeletonInstance_T[CartNodeSkel] | None:
+        """
+        Read a cart node skeleton with request-local caching.
+
+        :param key: Key of the cart node to read.
+        :return: The cached or freshly read node skeleton or ``None`` if the
+            node does not exist (anymore).  Missing nodes are not cached, so a
+            later call re-checks the datastore.
+        """
         cache = current.request_data.get().setdefault("shop_cache_cart_skel", {})
         key = db.keyHelper(key, CartNodeSkel.kindName)
         try:
             parent_skel = cache[key]
         except KeyError:
             parent_skel = self.viewSkel("node")
-            assert parent_skel.read(key)
+            if not parent_skel.read(key):
+                logger.warning(f"Cart node {key=} doesn't exist (anymore)")
+                return None
             cache[key] = parent_skel
         return parent_skel
 
@@ -751,8 +782,31 @@ class Cart(ShopModuleAbstract, Tree):
         start: SkeletonInstance_T[CartNodeSkel | CartItemSkel],
         condition: t.Callable[[SkeletonInstance], bool] = (lambda skel: True),
     ) -> SkeletonInstance_T[CartNodeSkel] | None:
+        """
+        Walk the ``parententry`` chain upwards and return the first ancestor
+        node that satisfies *condition*.
+
+        The walk stops and returns ``None`` when
+
+        *   the root node is reached without a match,
+        *   the current entry has no ``parententry`` (detached entry),
+        *   a parent node does not exist anymore (orphaned entry) or
+        *   the ``parententry`` chain contains a cycle.
+
+        The latter cases are broken tree states which must not crash callers
+        like the price computation running inside deferred tasks.
+
+        :param start: Leaf or node skeleton to start from (itself excluded).
+        :param condition: Predicate evaluated for each ancestor node.
+        :return: The closest matching ancestor node or ``None``.
+        """
+        seen_keys = set()
         while True:
-            parent_skel = self.get_cached_cart_skel(start["parententry"])
+            if not (pk := start["parententry"]) or pk in seen_keys:
+                return None  # detached entry or cyclic parententry chain
+            seen_keys.add(pk)
+            if (parent_skel := self.get_cached_cart_skel(pk)) is None:
+                return None  # orphaned entry, the parent node has been deleted
             if condition(parent_skel):
                 return parent_skel  # type:ignore
             if parent_skel["is_root_node"]:

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -460,11 +460,20 @@ class CartItemSkel(TreeSkel):
         )
 
     @property
-    def parent_skel(self) -> SkeletonInstance:
+    def parent_skel(self) -> SkeletonInstance | None:
+        """
+        Skeleton of the parent cart node of this entry.
+
+        :return: The parent node skeleton or ``None`` if this entry has no
+            ``parententry`` or the parent node does not exist anymore
+            (orphaned entry).
+        """
         if not (pk := self["parententry"]):
             return None
         skel = SHOP_INSTANCE.get().cart.viewSkel("node")
-        assert skel.read(pk)
+        if not skel.read(pk):
+            logger.warning(f"Parent node {pk=} of {self['key']!r} doesn't exist (anymore)")
+            return None
         return skel
 
     @property

--- a/src/viur/shop/types/price.py
+++ b/src/viur/shop/types/price.py
@@ -107,7 +107,18 @@ class Price:
             except Exception as exc:  # FIXME: some entities are broken?
                 logger.exception(exc)
                 self.cart_discounts = []
-            self.cart_discounts = [toolkit.get_full_skel_from_ref_skel(d) for d in self.cart_discounts]
+            # Resolve the ref-skels to full skeletons and drop dangling
+            # relations (the discount entity has been deleted meanwhile,
+            # e.g. with RelationalConsistency.Ignore); an unloadable skel
+            # has no key and would crash the discount evaluation later.
+            cart_discounts = []
+            for ref_skel in self.cart_discounts:
+                full_skel = toolkit.get_full_skel_from_ref_skel(ref_skel)
+                if not full_skel["key"]:
+                    logger.warning(f'Ignoring dangling discount relation {ref_skel["key"]!r}')
+                    continue
+                cart_discounts.append(full_skel)
+            self.cart_discounts = cart_discounts
         elif is_skeletoninstance_of(src_object, shop.article_skel):
             self.is_in_cart = False
             self.article_skel = toolkit.without_render_preparation(src_object)


### PR DESCRIPTION
#### Problem
The cart tree helpers assume the `parententry` chain is always intact:

- `Cart.get_cached_cart_skel` used `assert parent_skel.read(key)`
- `Cart.get_discount_for_leaf` raised `InvalidStateError` for a missing parent
- `Cart.get_closest_node` looped `while True` without protection against missing parents or cyclic chains
- `CartItemSkel.parent_skel` used `assert skel.read(pk)`

When a `shop_cart_node` is deleted while children still reference it (orphaned entries — e.g. the child cleanup of `cart_remove` runs deferred via `deleteRecursive` and that task gets lost), every access to such a leaf crashes.

This is especially fatal in combination with the `price` bone (`ComputeMethod.Always`): the compute fires on every unserialize, including `skel.refresh()` inside `update_relations` tasks. The raised exception is answered by viur-core with HTTP 408, so the task queue retries the task **forever** — the queue fills up with tasks that can never succeed (observed in production with tasks at 100+ retry attempts).

Additionally, a `discount` relation whose target was deleted (`RelationalConsistency.Ignore` is the default) produced an unloadable skeleton in `Price.__init__` — the dereferencing at the end was outside the existing `try`/`except` and crashed the discount evaluation later.

Note: the bare `assert`s would be stripped under `python -O`, silently continuing with unloaded skeletons instead.

#### Solution
- `get_cached_cart_skel` returns `None` for missing nodes (with a warning; negative results are not cached)
- `get_closest_node` stops gracefully on detached entries, missing parents and cyclic `parententry` chains (visited-set)
- `get_discount_for_leaf` stops the walk at broken links / cycles and returns the discounts collected so far
- `CartItemSkel.parent_skel` returns `None` instead of asserting
- `Price.__init__` skips dangling discount relations (unloadable full skels) with a warning
- Docstrings added to all touched methods describing the tolerant behaviour

Broken tree data now degrades gracefully (with warnings in the log) instead of permanently crashing deferred tasks. Cleaning up orphaned entries stays a separate concern (follow-up PR with a garbage collection task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)