### PR TITLE
fix: Don't retry `check_payment_deferred` forever when the order vanished

### DIFF
--- a/src/viur/shop/payment_providers/abstract.py
+++ b/src/viur/shop/payment_providers/abstract.py
@@ -126,9 +126,23 @@ class PaymentProviderAbstract(InstancedModule, Module, abc.ABC):
     @CallDeferred
     # @log_unzer_error
     def check_payment_deferred(self, order_key: db.Key) -> None:
-        """Check the status for a payment deferred"""
+        """
+        Check the status for a payment deferred.
+
+        Queries the payment provider for the current payment state and marks
+        the order as paid if necessary.
+
+        If the order does not exist (anymore) -- e.g. it has been deleted
+        between the webhook call that scheduled this task and its (delayed)
+        execution -- the task logs a warning and returns.  It must not raise
+        in this case: the task queue would retry a raising task forever,
+        although the order can never come back.
+        """
         logger.debug(f"Checking payment for {order_key=!r} deferred")
-        order_skel = self.shop.order.skel().read(order_key)
+        order_skel = self.shop.order.skel()
+        if not order_skel.read(order_key):
+            logger.warning(f"Order {order_key!r} doesn't exist (anymore); skipping deferred payment check")
+            return
         logger.debug(f"Checking payment for {order_skel=!r} deferred")
         # TODO: duplicate check / code?
         is_paid, payment = self.check_payment_state(order_skel)


### PR DESCRIPTION
#### Problem
`PaymentProviderAbstract.check_payment_deferred` assigns the result of `self.shop.order.skel().read(order_key)` without checking it:

```python
order_skel = self.shop.order.skel().read(order_key)
is_paid, payment = self.check_payment_state(order_skel)
```

If the order was deleted between the webhook call that scheduled this task (e.g. `UnzerAbstract.webhook` schedules it with `_countdown=60`) and its execution, `read()` returns `None` and `check_payment_state` crashes with `TypeError: 'NoneType' object is not subscriptable`.

Since the method is `@CallDeferred`, the exception is answered by viur-core with HTTP 408 and the task queue **retries the task forever** — the order can never come back, so the task can never succeed and clogs the queue permanently.

#### Solution
Check the `read()` result; log a warning and return when the order does not exist (anymore). Docstring added describing this behaviour and why the task must not raise here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)