### PR TITLE
fix: Delete cart children before the node in `cart_remove` to prevent orphans

### DIFF
--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -3,7 +3,7 @@ import typing as t  # noqa
 import viur.shop.types.exceptions as e
 from viur import toolkit
 from viur.core import conf, current, db, errors, exposed, translate
-from viur.core.bones import BaseBone
+from viur.core.bones import BaseBone, RelationalConsistency
 from viur.core.prototypes import Tree
 from viur.core.prototypes.tree import SkelType
 from viur.core.session import Session
@@ -571,9 +571,18 @@ class Cart(ShopModuleAbstract, Tree):
 
         Frozen carts belong to an order and cannot be removed.
 
+        This also checks upfront whether the node is locked by a
+        ``RelationalConsistency.PreventDeletion`` relation (e.g. an order
+        referencing an in-progress checkout cart that has not been frozen
+        yet) and fails before touching any child -- deleting the children
+        first and finding out only at ``skel.delete()`` that the node itself
+        is locked would leave the order pointing at an emptied-out cart.
+
         :param cart_key: Key of the cart node to remove.
         :raises errors.NotFound: If the cart node does not exist.
         :raises errors.Forbidden: If the cart node is frozen.
+        :raises errors.Locked: If the cart node is referenced by a
+            PreventDeletion relation (e.g. an order).
         """
         skel = self.editSkel("node")
         if not skel.read(cart_key):
@@ -583,8 +592,14 @@ class Cart(ShopModuleAbstract, Tree):
                 translate("viur.shop.error.cart.is_frozen",
                           default_variables={"cart_key": cart_key})
             )
+        if (
+            db.Query("viur-relations")
+                .filter("dest.__key__ =", cart_key)
+                .filter("viur_relational_consistency =", RelationalConsistency.PreventDeletion.value)
+                .getEntry()
+        ) is not None:
+            raise errors.Locked("This entry is still referenced by other Skeletons, which prevents deleting!")
         self._delete_children(cart_key)
-        # This delete could fail if the cart is used by an order (PreventDeletion)
         skel.delete()
         if skel["parententry"] is None or skel["is_root_node"]:
             logger.info(f"{skel['key']} was a root node!")

--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -617,11 +617,20 @@ class Cart(ShopModuleAbstract, Tree):
 
         Leafs of *parent_cart_key* are deleted first, then each sub-node is
         processed recursively (its own children before the sub-node itself).
-        In contrast to the deferred :meth:`deleteRecursive` of the Tree
-        prototype this runs synchronously: a lost cleanup task can therefore
-        no longer leave orphaned children behind, whose broken
-        ``parententry`` chain would crash price computations and
-        ``update_relations`` tasks later.
+
+        Deliberately does not call the inherited :meth:`deleteRecursive` of
+        the Tree prototype: that method is ``@CallDeferred`` and only deletes
+        the children, while the node itself is deleted synchronously by the
+        caller right away (see :meth:`Tree.delete` / :meth:`cart_remove`).
+        If that deferred task gets lost (queue purge, crash, or the task
+        being pinned to an App Engine version that no longer exists), the
+        node is gone but its children survive it forever -- orphaned
+        entries whose broken ``parententry`` chain crashes price
+        computations and ``update_relations`` tasks later. Cart trees are
+        small (a handful of nodes/leafs), so there is no need to defer this
+        work at all; running it synchronously, bottom-up and before the
+        node itself is deleted removes the race entirely instead of just
+        narrowing it.
 
         :param parent_cart_key: Key of the cart node whose subtree gets deleted.
         """

--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -532,12 +532,33 @@ class Cart(ShopModuleAbstract, Tree):
         self,
         cart_key: db.Key,
     ) -> None:
+        """
+        Remove a cart node with its entire subtree.
+
+        The subtree is deleted bottom-up and **before** the node itself:
+        leafs first, then sub-nodes, the given node last.  This order keeps
+        the tree consistent at any point in time -- if the process crashes
+        in between, no children can be left behind whose ``parententry``
+        points to an already deleted node (orphaned entries).  A repeated
+        call simply continues the work (idempotent).
+
+        Frozen carts belong to an order and cannot be removed.
+
+        :param cart_key: Key of the cart node to remove.
+        :raises errors.NotFound: If the cart node does not exist.
+        :raises errors.Forbidden: If the cart node is frozen.
+        """
         skel = self.editSkel("node")
         if not skel.read(cart_key):
             raise errors.NotFound
-        # This delete could fail if the cart is used by an order
+        if skel["is_frozen"]:
+            raise errors.Forbidden(
+                translate("viur.shop.error.cart.is_frozen",
+                          default_variables={"cart_key": cart_key})
+            )
+        self._delete_children(cart_key)
+        # This delete could fail if the cart is used by an order (PreventDeletion)
         skel.delete()
-        self.deleteRecursive(cart_key)
         if skel["parententry"] is None or skel["is_root_node"]:
             logger.info(f"{skel['key']} was a root node!")
             # raise NotImplementedError("Cannot delete root node")
@@ -547,6 +568,26 @@ class Cart(ShopModuleAbstract, Tree):
                 # del self.session["session_cart_key"]
                 # current.session.get().markChanged()
         EVENT_SERVICE.call(Event.CART_CHANGED, skel=skel, deleted=True)
+
+    def _delete_children(self, parent_cart_key: db.Key) -> None:
+        """
+        Delete all children of a cart node bottom-up and synchronously.
+
+        Leafs of *parent_cart_key* are deleted first, then each sub-node is
+        processed recursively (its own children before the sub-node itself).
+        In contrast to the deferred :meth:`deleteRecursive` of the Tree
+        prototype this runs synchronously: a lost cleanup task can therefore
+        no longer leave orphaned children behind, whose broken
+        ``parententry`` chain would crash price computations and
+        ``update_relations`` tasks later.
+
+        :param parent_cart_key: Key of the cart node whose subtree gets deleted.
+        """
+        for leaf_skel in toolkit.iter_skel(self.editSkel("leaf").all().filter("parententry =", parent_cart_key)):
+            leaf_skel.delete()
+        for node_skel in toolkit.iter_skel(self.editSkel("node").all().filter("parententry =", parent_cart_key)):
+            self._delete_children(node_skel["key"])
+            node_skel.delete()
 
     def cart_clear(
         self,
@@ -771,19 +812,33 @@ except AttributeError:  # backward compatibility for viur-core
 
 @Session.on_delete
 def delete_guest_cart(session: db.Entity) -> None:
-    """Delete carts from guest sessions to avoid orphaned carts"""
+    """
+    Delete carts from guest sessions to avoid orphaned carts.
+
+    Runs as :meth:`Session.on_delete` hook.  Any failure is logged and
+    swallowed: this hook must never prevent the session deletion itself.
+    Carts that are referenced by an order, already gone or frozen are
+    left alone.
+    """
     if session["user"] != Session.GUEST_USER:
         return
     try:
         cart = session["data"]["shop"]["cart"]["session_cart_key"]
     except (KeyError, TypeError):
         return
-    if (
-        SHOP_INSTANCE.get().order.skel().all()
-            .filter("cart.dest.__key__", cart)
-            .getSkel()
-    ) is not None:
-        # Is used by an order
-        return
-    SHOP_INSTANCE.get().cart.cart_remove(cart)
-    logger.debug(f"Deleted {cart=} and children after deleting {session=}")
+    try:
+        if (
+            SHOP_INSTANCE.get().order.skel().all()
+                .filter("cart.dest.__key__", cart)
+                .getSkel()
+        ) is not None:
+            # Is used by an order
+            return
+        SHOP_INSTANCE.get().cart.cart_remove(cart)
+        logger.debug(f"Deleted {cart=} and children after deleting {session=}")
+    except errors.NotFound:
+        logger.info(f"Cart {cart!r} of deleted session doesn't exist (anymore); nothing to do")
+    except errors.Forbidden:
+        logger.info(f"Cart {cart!r} of deleted session is frozen; keeping it")
+    except Exception:
+        logger.exception(f"Failed to delete guest cart {cart!r}; keeping it")


### PR DESCRIPTION
#### Problem
`Cart.cart_remove` removes a cart in this order:

```python
skel.delete()                    # node deleted synchronously
self.deleteRecursive(cart_key)   # children deleted by a deferred task
```

`deleteRecursive` (Tree prototype) is `@CallDeferred` — the children are cleaned up by a separate Cloud Task, and every recursion level spawns yet another task. If any of these tasks is lost (queue purge, crash, task routing pinned to a meanwhile deleted App Engine version), the children permanently survive their parent.

Such orphaned `cart_leaf` / `cart_node` entries are toxic: their broken `parententry` chain makes the `price` compute (`ComputeMethod.Always`) raise on every unserialize — including inside `update_relations` tasks, which then fail with HTTP 408 and are retried by the task queue forever (observed in production: task queues clogged with tasks at 100+ retry attempts, plus hundreds of orphaned leaf entries).

Additionally `cart_remove` had no `is_frozen` guard, so sub-nodes of an ordered (frozen) cart could be removed (e.g. via `Discount.remove` → `cart_remove` on a `FREE_ARTICLE` sub-node), leaving the order pointing at an inconsistent tree.

The `delete_guest_cart` session hook also propagated exceptions (`NotFound` for an already deleted cart), which can break the session deletion it is attached to.

#### Solution
- New `Cart._delete_children`: deletes the subtree **bottom-up and synchronously** (leafs first, then sub-nodes recursively), the given node itself is deleted **last**. At any point in time the tree stays consistent: a crash mid-way leaves a smaller but intact tree, and a repeated call continues the work (idempotent). Carts are user-sized, so there is no need to defer this work.
- `cart_remove` refuses to remove frozen carts (`errors.Forbidden`, same translation key as `cart_clear`).
- `delete_guest_cart` catches and logs all failures (`NotFound` → nothing to do, `Forbidden` → cart is frozen and stays, anything else → logged with traceback); the `Session.on_delete` hook never blocks the session deletion anymore.
- Docstrings added describing the deletion order guarantees.

#### Note
Orphaned entries created in the past are not repaired by this PR; a follow-up provides a cleanup/GC task. Tolerance of the tree navigation against existing orphans is addressed in #182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)