### PR TITLE
fix: Respect `is_frozen` in cart computes and mutation paths

### DIFF
--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -300,6 +300,12 @@ class Cart(ShopModuleAbstract, Tree):
             skel = self.copy_article_values(article_skel, skel)
         else:
             parent_skel = skel.parent_skel
+        if parent_skel and parent_skel["is_frozen"]:
+            # The cart belongs to a placed order and must not change anymore
+            raise errors.Forbidden(
+                translate("viur.shop.error.cart.is_frozen",
+                          default_variables={"cart_key": parent_skel["key"]})
+            )
         if quantity == 0 and quantity_mode in (QuantityMode.INCREASE, QuantityMode.DECREASE):
             raise e.InvalidArgumentException(
                 "quantity",
@@ -388,6 +394,13 @@ class Cart(ShopModuleAbstract, Tree):
                 "new_parent_cart_key", new_parent_cart_key,
                 f"Target cart node is inside a different repo"
             )
+        if skel["is_frozen"] or parent_skel["is_frozen"]:
+            # Neither an ordered (frozen) item may be moved away
+            # nor may an item be moved into a frozen cart
+            raise errors.Forbidden(
+                translate("viur.shop.error.cart.is_frozen",
+                          default_variables={"cart_key": parent_skel["key"]})
+            )
         skel["parententry"] = new_parent_cart_key
         skel.write()
         EVENT_SERVICE.call(Event.ARTICLE_CHANGED, skel=skel, deleted=False)
@@ -454,6 +467,12 @@ class Cart(ShopModuleAbstract, Tree):
         # if not self.canEdit(skel):
         #     raise errors.Forbidden
         assert skel.read(cart_key)
+        if skel["is_frozen"]:
+            # The cart belongs to a placed order and must not change anymore
+            raise errors.Forbidden(
+                translate("viur.shop.error.cart.is_frozen",
+                          default_variables={"cart_key": cart_key})
+            )
         skel = self._cart_set_values(
             skel=skel,
             parent_cart_key=parent_cart_key,

--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -397,9 +397,10 @@ class Cart(ShopModuleAbstract, Tree):
         if skel["is_frozen"] or parent_skel["is_frozen"]:
             # Neither an ordered (frozen) item may be moved away
             # nor may an item be moved into a frozen cart
+            frozen_cart_key = parent_cart_key if skel["is_frozen"] else new_parent_cart_key
             raise errors.Forbidden(
                 translate("viur.shop.error.cart.is_frozen",
-                          default_variables={"cart_key": parent_skel["key"]})
+                          default_variables={"cart_key": frozen_cart_key})
             )
         skel["parententry"] = new_parent_cart_key
         skel.write()

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -48,8 +48,19 @@ class TotalFactory:
         else:
             return SHOP_INSTANCE.get().cart.get_children(parent_cart_key)
 
-    def __call__(self, skel: SkeletonInstance_T["CartNodeSkel"], bone: NumericBone):
+    def __call__(self, skel: SkeletonInstance_T["CartNodeSkel"], bone: NumericBone, bone_name: str):
+        """
+        Compute the total of *bone_name* by aggregating the children.
+
+        Frozen carts (``is_frozen``) return the snapshot stored in
+        ``frozen_values`` at freeze time instead of recomputing: totals of an
+        ordered cart must not change anymore when article prices, discounts
+        or shippings change afterwards.  (Frozen entries written before
+        ``frozen_values`` existed fall back to live computation.)
+        """
         skel = without_render_preparation(skel)
+        if skel["is_frozen"] and (frozen_values := skel["frozen_values"]) and bone_name in frozen_values:
+            return frozen_values[bone_name]
         children = self._get_children(skel["key"])
         total = 0
         for child in children:
@@ -98,7 +109,16 @@ def add_shipping(factory: TotalFactory, total: float, skel: "SkeletonInstance", 
 
 # @toolkit.debug
 def get_vat_for_node(skel: "CartNodeSkel", bone: RecordBone) -> list[dict]:
+    """
+    Compute the VAT shares of a cart node from its children.
+
+    Frozen carts (``is_frozen``) return the snapshot stored in
+    ``frozen_values`` at freeze time instead of recomputing (see
+    :meth:`TotalFactory.__call__`).
+    """
     skel = without_render_preparation(skel)
+    if skel["is_frozen"] and (frozen_values := skel["frozen_values"]) and "vat" in frozen_values:
+        return frozen_values["vat"]
     children = SHOP_INSTANCE.get().cart.get_children_from_cache(skel["key"])
     cat2value = collections.defaultdict(lambda: 0)
     cat2rate = {}
@@ -140,6 +160,35 @@ def get_vat_for_node(skel: "CartNodeSkel", bone: RecordBone) -> list[dict]:
         for cat, value in cat2value.items()
         if cat and value
     ]
+
+
+def get_price_for_leaf(skel: SkeletonInstance_T["CartItemSkel"]) -> dict:
+    """
+    Compute the price dict of a cart leaf.
+
+    Frozen leafs (``is_frozen``) return the price snapshot stored in
+    ``frozen_values`` at freeze time instead of recomputing: the price of an
+    ordered item must not change anymore when the article prices or
+    discounts change afterwards.  (Frozen entries written before
+    ``frozen_values`` existed fall back to live computation.)
+    """
+    if skel["is_frozen"] and (frozen_values := skel["frozen_values"]) and frozen_values.get("price"):
+        return frozen_values["price"]
+    return skel.price_.to_dict()
+
+
+def get_shipping_for_leaf(skel: SkeletonInstance_T["CartItemSkel"]) -> dict | None:
+    """
+    Compute the shipping dict of a cart leaf.
+
+    Frozen leafs return the snapshot stored in ``frozen_values`` at freeze
+    time (see :func:`get_price_for_leaf`).
+    """
+    if skel["is_frozen"] and (frozen_values := skel["frozen_values"]) and "shipping" in frozen_values:
+        return frozen_values["shipping"]
+    return make_json_dumpable(
+        SHOP_INSTANCE.get().shipping.choose_shipping_skel_for_article(skel.article_skel_full)
+    )
 
 
 class RelationalBoneShipping(RelationalBone):
@@ -472,15 +521,11 @@ class CartItemSkel(TreeSkel):
         return Price.get_or_create(self)
 
     price = JsonBone(
-        compute=Compute(lambda skel: skel.price_.to_dict(), ComputeInterval(ComputeMethod.Always))
+        compute=Compute(get_price_for_leaf, ComputeInterval(ComputeMethod.Always))
     )
 
     shipping = JsonBone(
-        compute=Compute(
-            lambda skel: make_json_dumpable(
-                SHOP_INSTANCE.get().shipping.choose_shipping_skel_for_article(skel.article_skel_full)
-            ),
-            ComputeInterval(ComputeMethod.Always)),
+        compute=Compute(get_shipping_for_leaf, ComputeInterval(ComputeMethod.Always)),
     )
 
     is_frozen = BooleanBone(

--- a/src/viur/shop/skeletons/order.py
+++ b/src/viur/shop/skeletons/order.py
@@ -158,6 +158,16 @@ class OrderSkel(Skeleton):
 
     @classmethod
     def read(cls, skel: SkeletonInstance, *args, **kwargs) -> t.Optional[SkeletonInstance]:
+        """
+        Read the order skeleton.
+
+        For open orders the ``cart`` relation is refreshed to work around
+        race-condition and timing issues with its dest values.  Completed
+        orders (``is_ordered``) are exempt: their cart is frozen and the
+        relation must keep the values from order time -- refreshing it
+        would overwrite them and let the order change retroactively.
+        """
         if res := super().read(skel, *args, **kwargs):
-            cls.refresh_cart(skel)
+            if not skel["is_ordered"]:
+                cls.refresh_cart(skel)
         return res


### PR DESCRIPTION
#### Problem
`freeze_cart` / `freeze_leaf` mark a cart tree as `is_frozen` and store a snapshot of the totals in `frozen_values` — but nothing ever read that snapshot:

1. **Totals of placed orders changed retroactively.** `total`, `total_raw`, `total_discount_price`, `vat`, `total_quantity` (via `TotalFactory` / `get_vat_for_node`) and the leaf `price` / `shipping` bones are `ComputeMethod.Always` and recomputed live values from the *current* article prices, discounts and shipping costs on every unserialize — regardless of `is_frozen`. Only `RelationalBoneShipping` respected the flag.
2. **`OrderSkel.read` propagated those live values into the order**: it refreshes the `cart` relation on every read, so the refKeys (`total`, `vat`, …) of a completed order followed later price changes and could diverge from the fixed scalar `OrderSkel.total`.
3. **The content of an ordered cart was still mutable**: `add_or_update_article`, `move_article` and `cart_update` had no `is_frozen` guard (only `cart_clear` had one) — articles could be added to, changed in or moved out of a frozen cart, silently invalidating the frozen totals.

#### Solution
- `TotalFactory.__call__` (now also receiving `bone_name`), `get_vat_for_node` and the new named compute functions `get_price_for_leaf` / `get_shipping_for_leaf` return the `frozen_values` snapshot for frozen entries. Frozen entries written before `frozen_values` existed fall back to live computation.
- `OrderSkel.read` refreshes the `cart` relation only for open orders (`is_ordered` is falsy); completed orders keep the relation values from order time.
- `add_or_update_article`, `move_article` (both directions: frozen item, frozen target cart) and `cart_update` raise `errors.Forbidden` on frozen carts, using the same translation key as `cart_clear`.
- Docstrings added describing the freeze semantics at all touched code paths.

#### Behaviour change
Reading a frozen cart no longer recomputes its totals. If a project relied on frozen carts showing *current* prices (unlikely, since `freeze_*` exists to prevent exactly that), it would need to unfreeze instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)