### PR TITLE
fix: Don't refresh all cart leafs on every article write

### DIFF
--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -376,7 +376,19 @@ class CartItemSkel(TreeSkel):
             "shop_*",
         ],
         consistency=RelationalConsistency.CascadeDeletion,
+        updateLevel=RelationalUpdateLevel.OnValueAssignment,
     )
+    """Relation to the article this cart item stands for.
+
+    The ``shop_*`` refKeys are a snapshot taken when the article is put
+    into the cart (see :meth:`Cart.copy_article_values` and the "frozen
+    copy" bones below); current prices are always computed live through
+    :attr:`price`.  Therefore the relation uses
+    :attr:`RelationalUpdateLevel.OnValueAssignment`: with the default
+    (``Always``), every article write would spawn an ``update_relations``
+    task refreshing *every* cart leaf (including years-old abandoned
+    baskets) that references the article -- without any effect on the
+    prices being displayed or charged."""
 
     quantity = NumericBone(
         min=0,


### PR DESCRIPTION
> Opened as **draft** because this is a deliberate behaviour change of the relation semantics — please discuss.

#### Problem
`CartItemSkel.article` uses the default `updateLevel` of `RelationalBone`, which is `RelationalUpdateLevel.Always`. Consequence: **every write of an article** spawns an `update_relations` task that refreshes **every** `cart_leaf` referencing that article — including years-old abandoned session baskets.

In a production system with frequent article imports this:
- floods the task queue with refresh work on every import run,
- touches (rewrites) historic cart leafs constantly, and
- in combination with broken tree data (orphaned leafs, see #182/#184), produced `update-relations` tasks that failed with 408 and were retried forever.

#### Why the refresh is not needed
- The `shop_*` refKeys of the relation are a snapshot taken when the article is put into the cart (`copy_article_values`) — the skeleton itself documents them as *"Bones to store a frozen copy of the article values"*.
- The price shown and charged is always computed live via the `price` bone (`ComputeMethod.Always` → `Price` → `article_skel_full`, which reads the **full article entity**, not the refKeys).
- Frozen (ordered) carts must not change at all (see #185).

So the automatic relation refresh performs work that has no effect on what customers see or pay.

#### Solution
Set `updateLevel=RelationalUpdateLevel.OnValueAssignment` on `CartItemSkel.article`; the refKeys snapshot is then only written when the relation itself is (re)assigned. Docstring on the bone explains the reasoning.

#### Impact to discuss
Projects that read the `article.dest.shop_*` refKeys of *open* carts directly (instead of the leaf's own `shop_*` copies or the `price` bone) would no longer see article changes reflected automatically. If that is a supported use case, an alternative would be a targeted refresh of only *active* carts — but the default of refreshing every historic leaf on every article write seems clearly unintended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)