### PR TITLE
fix: Set explicit `RelationalConsistency` on cart and order relations

### DIFF
--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -312,7 +312,13 @@ class CartNodeSkel(TreeSkel):
             "supplier",
             "delivery_time_range",
         ],
+        consistency=RelationalConsistency.SetNull,
     )
+    """Selected shipping for this cart node.
+
+    Uses ``SetNull`` consistency: when the referenced shipping entry gets
+    deleted, the relation is cleared instead of silently keeping a dangling
+    reference with stale ``shipping_cost`` values in the totals."""
     shipping_status = SelectBone(
         values=ShippingStatus,
         defaultValue=ShippingStatus.CHEAPEST
@@ -330,7 +336,14 @@ class CartNodeSkel(TreeSkel):
             "percentage",
             "condition"
         ],
+        consistency=RelationalConsistency.SetNull,
     )
+    """Discount applied to this cart node.
+
+    Uses ``SetNull`` consistency: when the referenced discount gets deleted,
+    the relation is cleared -- a dangling reference would still be applied
+    with its cached refKey values by ``add_discount`` and crash the discount
+    evaluation in the price calculation."""
 
     project_data = JsonBone(
     )

--- a/src/viur/shop/skeletons/order.py
+++ b/src/viur/shop/skeletons/order.py
@@ -37,7 +37,13 @@ class OrderSkel(Skeleton):
         kind="user",
         searchable=True,
         refKeys={"name", "creationdate"},
+        consistency=RelationalConsistency.SetNull,
     )
+    """The user who placed this order.
+
+    Uses ``SetNull`` consistency: deleting a user account clears the
+    relation instead of leaving a dangling reference.  The order itself and
+    its billing/shipping data stay untouched."""
 
     cart = TreeNodeBone(
         kind="{{viur_shop_modulename}}_cart_node",


### PR DESCRIPTION
#### Problem
Several relations used the default `RelationalConsistency.Ignore`, so deleting the referenced entity silently left a **dangling relation**:

| Bone | Effect of a dangling reference |
|---|---|
| `CartNodeSkel.discount` | `add_discount` still applies the cached refKey values; resolving the full skel in `Price.__init__` yields an unloadable skeleton and crashes the discount evaluation |
| `CartNodeSkel.shipping` | `add_shipping` keeps adding the stale `shipping_cost` to `total` forever |
| `OrderSkel.customer` | deleted user accounts leave dangling references on their orders |

#### Solution
Set `consistency=RelationalConsistency.SetNull` on all three bones — deleting the target now clears the relation on the referencing entries. Docstrings on the bones explain the choice.

`CartNodeSkel.shipping_address` is deliberately **not** touched here: `SetNull` would wipe the shipping address off frozen order carts, `PreventDeletion` would block users from ever deleting an address referenced by any stale session basket. The address snapshot approach from #179 (develop) is the proper solution for that bone.

#### Note
`SetNull` only affects future deletions; existing dangling relations are not repaired. Tolerance against those is covered by #182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)