### PR TITLE
fix: Harden discount, price and cart evaluation against broken data

### DIFF
--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -102,8 +102,16 @@ class Cart(ShopModuleAbstract, Tree):
                 self._set_basket_txn(user_key=user["key"], basket_key=root_node["key"])
         return self.session["session_cart_key"]
 
-    def detach_session_cart(self) -> db.Key:
-        key = self.session["session_cart_key"]
+    def detach_session_cart(self) -> db.Key | None:
+        """
+        Unlink the current cart from the session (and the user's basket).
+
+        The cart entity itself is kept.  Tolerates a session that has no
+        ``session_cart_key`` (anymore) instead of raising a ``KeyError``.
+
+        :return: The key of the detached cart, or ``None`` if none was set.
+        """
+        key = self.session.get("session_cart_key")
         self.session["session_cart_key"] = None
         current.session.get().markChanged()
         if user := current.user.get():

--- a/src/viur/shop/modules/discount_condition.py
+++ b/src/viur/shop/modules/discount_condition.py
@@ -201,7 +201,9 @@ class DiscountCondition(ShopModuleAbstract, List):
 
         for discount in discounts:
             d_skel = self.shop.discount.viewSkel()
-            d_skel.read(discount)
+            if not d_skel.read(discount):
+                logger.warning(f"Discount {discount!r} doesn't exist (anymore); cannot mark it as used")
+                continue
             for condition in d_skel["condition"]:
                 # TODO: Increase only "active" conditions in case of OR operator
                 # cond_skel = toolkit.get_full_skel_from_ref_skel(condition["dest"])

--- a/src/viur/shop/types/dc_scope.py
+++ b/src/viur/shop/types/dc_scope.py
@@ -259,10 +259,12 @@ class DiscountValidator:
         # We need the full skel with all bones (otherwise the refSkel would be to large)
         for condition in discount_skel["condition"]:
             if not (condition_skel := SHOP_INSTANCE.get().discount_condition.get_skel(condition["dest"]["key"])):
-                logger.warning(f'Broken relation {condition=} in {discount_skel["key"]}?!')
-                raise InvalidStateError(f'Broken relation {condition=} in {discount_skel["key"]}?!')
-                self.condition_skels.append(None)  # TODO
-                self.condition_validator_instances.append(None)  # TODO
+                # A single discount with a broken condition relation must not
+                # crash the evaluation of *all* discounts (e.g. the automatic
+                # discounts); the safe direction is to never apply it.
+                logger.warning(f'Broken condition relation {condition=} in discount {discount_skel["key"]!r}; '
+                               f'treating discount as not fulfilled')
+                self._is_fulfilled = False
                 continue
             cv = ConditionValidator()(
                 cart_skel=cart_skel,
@@ -295,10 +297,21 @@ class DiscountValidator:
 
     @property
     def application_domain(self) -> ApplicationDomain:
+        """
+        The common application domain of all conditions.
+
+        :return: The specific domain of the conditions, or
+            :attr:`ApplicationDomain.ALL` if the conditions declare no
+            specific domain (previously a ``KeyError`` from ``set().pop()``).
+        :raises NotImplementedError: If the conditions declare more than one
+            specific domain.
+        """
         domains = {cm.condition_skel["application_domain"] for cm in self.condition_validator_instances}
         domains.discard(ApplicationDomain.ALL)
         if len(domains) > 1:
             raise NotImplementedError(f"Ambiguous application_domains: {domains=}")
+        if not domains:
+            return ApplicationDomain.ALL
         return domains.pop()
 
     def __repr__(self):
@@ -313,9 +326,17 @@ class DiscountValidator:
 
 @ConditionValidator.register
 class ScopeCode(DiscountConditionScope):
+    """
+    Validates that the given code matches the condition's code.
+
+    Applies to ``UNIVERSAL`` and ``INDIVIDUAL`` code conditions; without a
+    given code such a condition is never fulfilled (a code-bound discount
+    must not be applied automatically).
+    """
+
     def precondition(self) -> bool:
         return (
-            self.condition_skel["code_type"] in {CodeType.INDIVIDUAL, CodeType.INDIVIDUAL}
+            self.condition_skel["code_type"] in {CodeType.INDIVIDUAL, CodeType.UNIVERSAL}
             # and self.cart_skel is not None
         )
 
@@ -326,6 +347,8 @@ class ScopeCode(DiscountConditionScope):
         ):
             # logger.info(f'scope_code UNIVERSAL not reached ({self.condition_skel["scope_code"]=} != {self.code=})')
             logger.debug(f'scope_code {self.condition_skel["scope_code"]=} =?= {self.code=}')
+            if not isinstance(self.code, str) or not self.condition_skel["scope_code"]:
+                return False  # no code given (e.g. automatic discount evaluation)
             return self.condition_skel["scope_code"].lower() == self.code.lower()
         elif (
             self.condition_skel["code_type"] == CodeType.INDIVIDUAL
@@ -481,7 +504,7 @@ class ScopeCustomerGroup(DiscountConditionScope):
         )
         if self.condition_skel["scope_customer_group"] == CustomerGroup.FIRST_ORDER:
             return orders == 0
-        elif self.condition_skel["scope_customer_group"] == CustomerGroup.FIRST_ORDER:
+        elif self.condition_skel["scope_customer_group"] == CustomerGroup.FOLLOW_UP_ORDER:
             return orders > 0
         raise NotImplementedError
 

--- a/src/viur/shop/types/price.py
+++ b/src/viur/shop/types/price.py
@@ -310,8 +310,9 @@ class Price:
                 country=country,
                 category=toolkit.without_render_preparation(self.article_skel)["shop_vat_rate_category"],
             )
-        except ConfigurationError as e:  # TODO(discussion): Or re-raise or implement fallback?
-            logger.warning(f"No vat rate for article :: {e}")
+        except (ConfigurationError, ValueError) as e:  # TODO(discussion): Or re-raise or implement fallback?
+            # ValueError: e.g. an invalid country code from a dangling shipping_address relation
+            logger.error(f"No vat rate for article :: {e}")
             vat_rate = 0.0
         return (vat_rate or 0.0) / 100
 
@@ -442,6 +443,12 @@ class Price:
         """
         Request-local price cache to avoid recalculating prices during one request lifecycle.
 
+        In contexts without request data (e.g. some task or test contexts)
+        an unshared, empty dict is returned -- prices are then simply not
+        cached instead of crashing.
+
         :return: Dictionary keyed by skeleton key, with cached `Price` objects.
         """
+        if current.request_data.get() is None:
+            return {}
         return current.request_data.get().setdefault("viur.shop", {}).setdefault("price_cache", {})


### PR DESCRIPTION
Bundle of robustness fixes for crash paths and logic bugs found in an audit of invalid-data handling.

#### Crash paths
- **`DiscountValidator.__call__`**: a single discount with a broken `condition` relation raised `InvalidStateError` — since `current_automatically_discounts` evaluates all discounts in one (TTL-cached) pass, one broken relation crashed **every** automatic discount evaluation shop-wide. The discount is now treated as *not fulfilled* (safe direction) with a warning; removed the unreachable dead code after the former `raise`.
- **`DiscountValidator.application_domain`**: when all conditions declare `ApplicationDomain.ALL`, the set was empty after `discard(ALL)` and `set().pop()` raised `KeyError`. Returns `ApplicationDomain.ALL` now.
- **`ScopeCode.__call__`**: `self.code.lower()` crashed with `AttributeError` when no code was given (automatic discount evaluation); now returns `False` — a code-bound discount must never apply without its code.
- **`Price.vat_rate_percentage`**: `get_vat_rate_for_country` raises `ValueError` for an invalid country code (e.g. from a dangling `shipping_address` relation), which was not caught (only `ConfigurationError` was). Both are now handled with an *error* log and the existing 0.0 fallback.
- **`Price.get_cache`**: crashed with `AttributeError` in contexts without request data; now returns an uncached dict like `CartItemSkel.get_article_cache` already does.
- **`mark_discount_used`**: `d_skel.read(discount)` was unchecked — a deleted discount produced a half-read skeleton; now skipped with a warning.
- **`Cart.detach_session_cart`**: raised `KeyError` when the session had no `session_cart_key`; now tolerant (`.get`), returns `None`.

#### Copy-paste logic bugs
- **`ScopeCode.precondition`**: checked `code_type in {CodeType.INDIVIDUAL, CodeType.INDIVIDUAL}` — `UNIVERSAL` code conditions were never validated by this scope. Fixed to `{INDIVIDUAL, UNIVERSAL}`. ⚠️ Behaviour change: universal-code discounts now actually require their code (previously the scope simply didn't participate).
- **`ScopeCustomerGroup`**: the second branch compared against `CustomerGroup.FIRST_ORDER` again instead of `FOLLOW_UP_ORDER` — the "returning customer" group always fell through to `raise NotImplementedError`.

Docstrings added at the touched code paths describing the tolerant behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)