### PR TITLE
fix: Freeze carts completely and detach the session cart only on success

### DIFF
--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -655,12 +655,18 @@ class Cart(ShopModuleAbstract, Tree):
         :param cart_key: Key of the (sub-)cart skeleton.
         :return: The frozen CartNode skeleton.
         """
+        # Iterate the children without a fetch limit: a partially frozen
+        # cart would keep recomputing (and thereby changing) the totals of
+        # the unfrozen entries after the order has been placed.
         child: SkeletonInstance_T[CartNodeSkel | CartItemSkel]
-        for child in self.get_children(cart_key):
-            if issubclass(child.skeletonCls, CartNodeSkel):
-                self.freeze_cart(child["key"])
-            else:
-                self.freeze_leaf(child)
+        for skel_type in ("node", "leaf"):
+            for child in toolkit.iter_skel(
+                self.viewSkel(skel_type).all().filter("parententry =", cart_key)
+            ):
+                if skel_type == "node":
+                    self.freeze_cart(child["key"])
+                else:
+                    self.freeze_leaf(child)
 
         self.clear_children_cache()
 

--- a/src/viur/shop/modules/order.py
+++ b/src/viur/shop/modules/order.py
@@ -302,10 +302,6 @@ class Order(ShopModuleAbstract, List):
             }, status_code=400)
             raise e.InvalidStateError(", ".join(errors))
 
-        if order_skel["cart"]["dest"]["key"] == self.shop.cart.current_session_cart_key:
-            # This is now an order basket and should no longer be modified
-            self.shop.cart.detach_session_cart()
-
         order_skel = self.freeze_order(order_skel)
         try:
             order_skel = HOOK_SERVICE.dispatch(Hook.ORDER_CHECKOUT_START_ADDITION)(order_skel)
@@ -313,6 +309,15 @@ class Order(ShopModuleAbstract, List):
             pass
         order_skel.write()
         self.set_checkout_in_progress(order_skel)
+
+        # Detach only after the checkout start succeeded completely:
+        # if freeze or write fails, the user keeps their session cart --
+        # detaching first would leave them with an empty new basket while
+        # the old cart dangles half-frozen behind the failed order.
+        if order_skel["cart"]["dest"]["key"] == self.shop.cart.current_session_cart_key:
+            # This is now an order basket and should no longer be modified
+            self.shop.cart.detach_session_cart()
+
         EVENT_SERVICE.call(Event.ORDER_CHANGED, order_skel=order_skel, deleted=False)
         return JsonResponse({
             "skel": order_skel,


### PR DESCRIPTION
#### Problem
1. **Partial freeze:** `freeze_cart` iterates children via `get_children`, which fetches at most `MAX_FETCH_LIMIT` (100) entries per skel type and level. A cart with more entries was only **partially frozen**: the entries beyond the limit never got `is_frozen` / `frozen_values`, so they keep recomputing with current prices — the totals of a placed order silently change afterwards.

2. **Premature detach:** `checkout_start` runs `detach_session_cart()` *before* `freeze_order()` and `order_skel.write()`. If freezing or writing raises, the user's session cart is already detached: they end up with a fresh empty basket on the next request, while the old cart dangles half-frozen behind a failed order.

#### Solution
- `freeze_cart` iterates the children per skel type without a fetch limit (`toolkit.iter_skel`), keeping the same order (sub-nodes first, then leafs).
- `checkout_start` detaches the session cart only **after** `freeze_order`, `write()` and `set_checkout_in_progress` succeeded. On failure the user keeps their (at worst partially frozen, but still owned) cart and can retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)