### PR TITLE
fix(`freeze_cart`): guard `shipping_address` for nested cart nodes

### DIFF
--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -674,7 +674,12 @@ class Cart(ShopModuleAbstract, Tree):
             "vat": cart_skel["vat"],
             "total_quantity": cart_skel["total_quantity"],
             "shipping": cart_skel["shipping"],
-            "shipping_address": cart_skel["shipping_address"]["dest"].dump(),
+            # Sub-nodes of the cart tree have no shipping_address (only the
+            # relevant node carries one), so guard against None here.
+            "shipping_address": (
+                cart_skel["shipping_address"]["dest"].dump()
+                if cart_skel["shipping_address"] else None
+            ),
             "discount": make_json_dumpable(cart_skel["discount"]),
         }
         cart_skel["is_frozen"] = True


### PR DESCRIPTION
## Problem

Freezing a cart during checkout crashes for **nested carts**:

```
File ".../shop/modules/cart.py", line ..., in freeze_cart
    "shipping_address": cart_skel["shipping_address"]["dest"].dump(),
TypeError: 'NoneType' object is not subscriptable
```

`freeze_cart` recurses over the whole cart tree and freezes every node. It assumed every node has a `shipping_address`, but only the relevant node (root) carries one — sub-nodes have `shipping_address = None`, so `None["dest"]` blows up.

## Fix

Guard the `shipping_address` dump and store `None` when the node has no address. Behaviour for nodes with an address is unchanged.