### PR TITLE
fix: keep order/cart address copies live until frozen

### DIFF
--- a/src/viur/shop/skeletons/_bones.py
+++ b/src/viur/shop/skeletons/_bones.py
@@ -41,15 +41,13 @@ class SnapshotRelationalBone(RelationalBone):
         self,
         *args: t.Any,
         is_frozen: t.Callable[[SkeletonInstance], bool] = lambda skel: bool(skel["is_frozen"]),
+        updateLevel: RelationalUpdateLevel = RelationalUpdateLevel.Always
         **kwargs: t.Any,
     ) -> None:
-        # The live-sync behaviour relies on updateLevel=Always: it keeps the
-        # relation in the update_relations query and prevents refresh() from
-        # short-circuiting. Freezing is handled by refresh() below instead, so
-        # any caller-provided updateLevel would break the contract and is
-        # therefore overridden here.
-        kwargs["updateLevel"] = RelationalUpdateLevel.Always
-        super().__init__(*args, **kwargs)
+        # The live-sync behaviour relies on updateLevel=Always
+        if updateLevel != RelationalUpdateLevel.Always:
+            raise ValueError("SnapshotRelationalBone only accepts RelationalUpdateLevel.Always")
+        super().__init__(updateLevel=updateLevel, *args, **kwargs)
         self.is_frozen = is_frozen
 
     def refresh(self, skel: SkeletonInstance, name: str) -> None:

--- a/src/viur/shop/skeletons/_bones.py
+++ b/src/viur/shop/skeletons/_bones.py
@@ -1,0 +1,61 @@
+import typing as t
+
+from viur.core.bones import RelationalBone, RelationalUpdateLevel
+from viur.core.skeleton import SkeletonInstance
+
+from ..globals import SHOP_LOGGER
+
+logger = SHOP_LOGGER.getChild(__name__)
+
+
+class SnapshotRelationalBone(RelationalBone):
+    """A :class:`RelationalBone` that keeps its cached ``refKeys`` copy in sync
+    while the owning skeleton is still editable, and freezes that copy once the
+    owning skeleton is frozen.
+
+    Background
+    ----------
+    viur-core only offers a *static* :class:`RelationalUpdateLevel`, and neither
+    value fits an order/cart address:
+
+    - ``Always`` keeps the cached copy in sync with the referenced entity, but a
+      completed (frozen) order would then change retroactively whenever the
+      referenced address gets edited later.
+    - ``OnValueAssignment`` freezes the copy at assignment time, but then never
+      reflects edits made to the referenced entity during an ongoing checkout
+      (e.g. the customer adds a birthdate in a later step or corrects the
+      address) -- the stale copy is what gets persisted with the order.
+
+    This bone combines both: it is configured with ``updateLevel=Always`` so the
+    copy is kept in sync -- both by the ``update_relations`` task (triggered when
+    the referenced entity changes) and by explicit :meth:`refresh` calls -- as
+    long as the owning skeleton is *not* frozen, and turns :meth:`refresh` into a
+    no-op once it *is* frozen, preserving the snapshot captured at freeze time.
+
+    :param is_frozen: Callable deciding whether the owning skeleton is frozen and
+        its snapshot must be preserved. Defaults to reading the boolean
+        ``is_frozen`` bone.
+    """
+
+    def __init__(
+        self,
+        *args: t.Any,
+        is_frozen: t.Callable[[SkeletonInstance], bool] = lambda skel: bool(skel["is_frozen"]),
+        **kwargs: t.Any,
+    ) -> None:
+        # The live-sync behaviour relies on updateLevel=Always: it keeps the
+        # relation in the update_relations query and prevents refresh() from
+        # short-circuiting. Freezing is handled by refresh() below instead, so
+        # any caller-provided updateLevel would break the contract and is
+        # therefore overridden here.
+        kwargs["updateLevel"] = RelationalUpdateLevel.Always
+        super().__init__(*args, **kwargs)
+        self.is_frozen = is_frozen
+
+    def refresh(self, skel: SkeletonInstance, name: str) -> None:
+        """Refresh the cached copy -- unless the owning skeleton is frozen, in
+        which case the snapshot captured at freeze time is preserved."""
+        if self.is_frozen(skel):
+            logger.debug(f"Skipping refresh of frozen {name!r} on {skel['key']!r}")
+            return
+        super().refresh(skel, name)

--- a/src/viur/shop/skeletons/_bones.py
+++ b/src/viur/shop/skeletons/_bones.py
@@ -41,12 +41,12 @@ class SnapshotRelationalBone(RelationalBone):
         self,
         *args: t.Any,
         is_frozen: t.Callable[[SkeletonInstance], bool] = lambda skel: bool(skel["is_frozen"]),
-        updateLevel: RelationalUpdateLevel = RelationalUpdateLevel.Always
+        updateLevel: RelationalUpdateLevel = RelationalUpdateLevel.Always,
         **kwargs: t.Any,
     ) -> None:
         # The live-sync behaviour relies on updateLevel=Always
         if updateLevel != RelationalUpdateLevel.Always:
-            raise ValueError("SnapshotRelationalBone only accepts RelationalUpdateLevel.Always")
+            raise ValueError(f"{type(self).__name__} only accepts RelationalUpdateLevel.Always")
         super().__init__(updateLevel=updateLevel, *args, **kwargs)
         self.is_frozen = is_frozen
 

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -8,6 +8,7 @@ from viur.core.prototypes.tree import TreeSkel
 from viur.core.skeleton import SkeletonInstance
 from viur.shop.types import *
 
+from ._bones import SnapshotRelationalBone
 from .vat import VatIncludedSkel
 from ..globals import SHOP_INSTANCE, SHOP_LOGGER
 from ..skeletons.article import ArticleAbstractSkel
@@ -320,14 +321,14 @@ class CartNodeSkel(TreeSkel):
         defaultValue=0,
     )
 
-    shipping_address = RelationalBone(
+    shipping_address = SnapshotRelationalBone(
         kind="{{viur_shop_modulename}}_address",
         module="{{viur_shop_modulename}}/address",
-        # keep shipping address persistent:
-        updateLevel=RelationalUpdateLevel.OnValueAssignment,
         refKeys={
             "*",
         },
+        # keep the copy in sync while the cart is open, freeze it once frozen
+        # (default is_frozen reads the CartNodeSkel.is_frozen bone):
     )
 
     customer_comment = TextBone(
@@ -412,6 +413,9 @@ class CartNodeSkel(TreeSkel):
         Due to race-condition and timing issues, the dest values are not always
         set correctly. This refresh fixes this.
         """
+        # Sub-node / total sub-skeletons don't carry the shipping_address bone.
+        if "shipping_address" not in skel:
+            return skel
         try:
             skel.shipping_address.refresh(skel, skel.shipping_address.name)
         except Exception as exc:

--- a/src/viur/shop/skeletons/order.py
+++ b/src/viur/shop/skeletons/order.py
@@ -4,6 +4,7 @@ from viur.core import translate
 from viur.core.bones import *
 from viur.core.skeleton import Skeleton, SkeletonInstance
 from viur.shop.types import *
+from ._bones import SnapshotRelationalBone
 from ..globals import SHOP_INSTANCE, SHOP_LOGGER
 
 logger = SHOP_LOGGER.getChild(__name__)
@@ -19,16 +20,16 @@ def get_payment_providers() -> dict[str, str | translate]:
 class OrderSkel(Skeleton):
     kindName = "{{viur_shop_modulename}}_order"
 
-    billing_address = RelationalBone(
+    billing_address = SnapshotRelationalBone(
         kind="{{viur_shop_modulename}}_address",
         module="{{viur_shop_modulename}}/address",
         searchable=True,
-        # keep billing address persistent:
-        updateLevel=RelationalUpdateLevel.OnValueAssignment,
         # keep all fields of the billing address as a copy:
         refKeys={
             "*",
         },
+        # keep the copy in sync while the order is open, freeze it once ordered:
+        is_frozen=lambda skel: bool(skel["is_ordered"]),
     )
 
     customer = RelationalBone(


### PR DESCRIPTION
## Summary

`OrderSkel.billing_address` and `CartNodeSkel.shipping_address` persist the referenced address as a copy (`refKeys="*"`). Since #179 they use `updateLevel=OnValueAssignment`, which freezes that copy already at **assignment time** — so any edit to the address during an ongoing checkout (adding a `birthdate` in a later step, correcting the address) was never mirrored onto the order/cart. `OnValueAssignment` additionally turned the existing `refresh_billing_address` / `refresh_shipping_address` helpers into silent no-ops.

## Fix

New `SnapshotRelationalBone`:

- configured with `updateLevel=Always`, so the copy is kept in sync — both by the `update_relations` task (target edited) and by explicit `refresh()` calls — while the owning skeleton is still editable;
- overrides `refresh()` to a no-op once the owning skeleton is frozen, preserving the snapshot captured at freeze time.

The freeze predicate is configurable: `is_ordered` for `OrderSkel.billing_address`, and the default `is_frozen` for `CartNodeSkel.shipping_address`.

Also guards `refresh_shipping_address` against sub-node skeletons that don't carry the `shipping_address` bone (previously raised `AttributeError` on every cart read of such a node).

## Trade-off

While a skeleton is frozen, editing a referenced address still triggers the `update_relations` task (the relation is serialized as `Always`) and re-writes the referencing order/cart once — but `refresh()` is a no-op there, so the persisted snapshot stays unchanged. Avoiding that extra write would require a dynamic serialized `updateLevel`, which is out of scope here.

## Test plan

- [x] Unit: `updateLevel` is forced to `Always`; `refresh()` runs while open and no-ops while frozen (both `is_ordered` and `is_frozen` predicates).
- [x] Dev server boots and serves with the change; full checkout re-verified manually — a `birthdate` added in a later step now propagates to the still-open order, and a frozen/completed order is no longer changed by later address edits.
