### PR TITLE
fix(cart): tolerate concurrent guest cart deletion

### DIFF
--- a/src/viur/shop/modules/cart.py
+++ b/src/viur/shop/modules/cart.py
@@ -948,5 +948,9 @@ def delete_guest_cart(session: db.Entity) -> None:
         logger.info(f"Cart {cart!r} of deleted session doesn't exist (anymore); nothing to do")
     except errors.Forbidden:
         logger.info(f"Cart {cart!r} of deleted session is frozen; keeping it")
+    except ValueError as exc:
+        # cart_remove() → skel.delete() raises a plain ValueError when the node
+        # was already deleted by a concurrent request; treat it as already-gone.
+        logger.info(f"Cart {cart!r} of deleted session could not be removed ({exc}); nothing to do")
     except Exception:
         logger.exception(f"Failed to delete guest cart {cart!r}; keeping it")


### PR DESCRIPTION
## Summary

- `delete_guest_cart` now catches `ValueError` and treats an already-removed cart node as already-gone (logged at info level).

## Motivation

`delete_guest_cart` removes the guest cart of a deleted session via `cart_remove()` → `skel.delete()`. When the cart node was already deleted by a concurrent request, viur-core's transactional delete raises a plain `ValueError("This skeleton is not in the database (anymore?)!")`.

This fell through to the broad `except Exception` and was logged via `logger.exception`, producing error-report noise for what is a benign race between concurrent session cleanups. The new handler catches `ValueError`, logs the actual message at info level, and keeps going.

## Test plan

- [ ] Deleting a guest cart that was concurrently removed logs at info level, not as an exception.
