### PR TITLE
feat: Add Unzer Direct Bank Transfer and Installment payment providers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ version = { attr = "viur.shop.version.__version__" }
 
 [project.optional-dependencies]
 unzer = [
-    "unzer~=1.4",
+    "unzer~=1.5",
 ]
 paypal = [
     "paypal-server-sdk~=1.0",

--- a/src/viur/shop/data/translations.py
+++ b/src/viur/shop/data/translations.py
@@ -134,6 +134,19 @@ TRANSLATIONS = {
         "de": "Flexibel bezahlen mit Klarna",
         "fr": "Paiement flexible avec Klarna",
     },
+    "viur.shop.payment_provider.unzer-paylater_installment": {
+        "_hint": "viur-shop payment provider: unzer-paylater_installment",
+        "_default_text": "Installment via Unzer",
+        "en": "Installment via Unzer",
+        "de": "Ratenkauf über Unzer",
+        "fr": "Paiement en plusieurs fois via Unzer",
+    },
+    "viur.shop.payment_provider.unzer-paylater_installment.descr": {
+        "_default_text": "Pay in monthly rates",
+        "en": "Pay in monthly rates",
+        "de": "In monatlichen Raten bezahlen",
+        "fr": "Payer en mensualités",
+    },
     "viur.shop.payment_provider.unzer-openbanking_pis": {
         "_hint": "viur-shop payment provider: unzer-openbanking_pis",
         "_default_text": "Direct bank transfer via Unzer",

--- a/src/viur/shop/data/translations.py
+++ b/src/viur/shop/data/translations.py
@@ -134,6 +134,19 @@ TRANSLATIONS = {
         "de": "Flexibel bezahlen mit Klarna",
         "fr": "Paiement flexible avec Klarna",
     },
+    "viur.shop.payment_provider.unzer-openbanking_pis": {
+        "_hint": "viur-shop payment provider: unzer-openbanking_pis",
+        "_default_text": "Direct bank transfer via Unzer",
+        "en": "Direct bank transfer via Unzer",
+        "de": "Direktüberweisung über Unzer",
+        "fr": "Virement bancaire direct via Unzer",
+    },
+    "viur.shop.payment_provider.unzer-openbanking_pis.descr": {
+        "_default_text": "Pay directly from your online banking",
+        "en": "Pay directly from your online banking",
+        "de": "Direkt aus Ihrem Online-Banking bezahlen",
+        "fr": "Payez directement depuis votre banque en ligne",
+    },
     "viur.shop.payment_provider.prepayment": {
         "_hint": "viur-shop Prepayment",
         "_default_text": "Prepayment",

--- a/src/viur/shop/modules/vat_rate.py
+++ b/src/viur/shop/modules/vat_rate.py
@@ -49,7 +49,13 @@ class VatRate(ShopModuleAbstract, List):
         country: str | None = None,
         category: VatRateCategory,
     ) -> float:
-        """Get the configured vat rate percentage for a country."""
+        """Get the configured vat rate percentage for a country.
+
+        :param country: The country to look up, as ISO 3166 ALPHA-2 code. Defaults to
+            the country of the current request.
+        :param category: The vat rate category to look up.
+        :return: The vat rate in percent, e.g. ``19.0``.
+        """
         if not isinstance(category, VatRateCategory):
             raise TypeError(f"{category!r} is not a VatRateCategory")
         if country is None:

--- a/src/viur/shop/payment_providers/__init__.py
+++ b/src/viur/shop/payment_providers/__init__.py
@@ -17,6 +17,7 @@ else:
     from .unzer_googlepay import UnzerGooglepay
     from .unzer_ideal import UnzerIdeal
     from .unzer_klarna import UnzerKlarna
+    from .unzer_openbanking_pis import UnzerOpenbankingPis
     from .unzer_paylater_invoice import UnzerPaylaterInvoice
     from .unzer_paypal import UnzerPayPal
     from .unzer_sofort import UnzerSofort

--- a/src/viur/shop/payment_providers/__init__.py
+++ b/src/viur/shop/payment_providers/__init__.py
@@ -18,6 +18,7 @@ else:
     from .unzer_ideal import UnzerIdeal
     from .unzer_klarna import UnzerKlarna
     from .unzer_openbanking_pis import UnzerOpenbankingPis
+    from .unzer_paylater_installment import UnzerPaylaterInstallment
     from .unzer_paylater_invoice import UnzerPaylaterInvoice
     from .unzer_paypal import UnzerPayPal
     from .unzer_sofort import UnzerSofort

--- a/src/viur/shop/payment_providers/abstract.py
+++ b/src/viur/shop/payment_providers/abstract.py
@@ -1,6 +1,7 @@
 import abc
 import enum
 import functools
+import urllib.parse
 import uuid
 
 from viur.core import CallDeferred, Module, current, db, translate, utils
@@ -37,12 +38,46 @@ class PaymentProviderAbstract(InstancedModule, Module, abc.ABC):
         *,
         image_path: str | None = None,
         is_available: t.Callable[[t.Self, SkeletonInstance_T[OrderSkel] | None], bool] | None = None,
+        return_url_host: str | t.Callable[[], str | None] | None = None,
     ) -> None:
         super().__init__()
         self.image_path = image_path
+        self._return_url_host = return_url_host
         if is_available is not None:
             assert callable(is_available), f"{is_available=} ({type(is_available)})"
             self.is_available = functools.partial(is_available, self)  # type: ignore[assignment]
+
+    @property
+    def return_url_host(self) -> str:
+        """Scheme and host the customer is redirected back to after the payment.
+
+        Defaults to the host of the current request. Configure it whenever that host
+        is of no use to the payment provider: a local development server is neither
+        publicly reachable nor accepted as a return URL by most providers.
+
+        Can be set to a plain string or to a callable; a callable returning ``None``
+        falls back to the current request as well, so a configuration only has to
+        name the host for the cases where it actually differs.
+        """
+        host = self._return_url_host() if callable(self._return_url_host) else self._return_url_host
+        return host or current.request.get().request.host_url
+
+    def get_return_url(
+        self,
+        order_skel: SkeletonInstance,
+        **params: str,
+    ) -> str:
+        """Build the URL the payment provider sends the customer back to.
+
+        :param order_skel: OrderSkel the payment belongs to.
+        :param params: Additional query parameters to pass through the payment.
+        :return: Absolute URL of this provider's ``return_handler``.
+        """
+        query = urllib.parse.urlencode({
+            "order_key": order_skel["key"].to_legacy_urlsafe().decode("ASCII"),
+            **params,
+        })
+        return f'{self.return_url_host.rstrip("/")}/{self.modulePath.strip("/")}/return_handler?{query}'
 
     @property
     @abc.abstractmethod

--- a/src/viur/shop/payment_providers/amazon_pay.py
+++ b/src/viur/shop/payment_providers/amazon_pay.py
@@ -1,6 +1,6 @@
 import typing as t  # noqa
 
-from viur.core import current, errors, exposed
+from viur.core import errors, exposed
 from viur.core.skeleton import SkeletonInstance
 from viur.shop.types import *
 from . import PaymentProviderAbstract
@@ -64,8 +64,7 @@ class AmazonPay(PaymentProviderAbstract):
         self,
         order_skel: SkeletonInstance,
     ) -> t.Any:
-        host = current.request.get().request.host_url
-        return_url = f'{host.rstrip("/")}/{self.modulePath.strip("/")}/return_handler?order_key={order_skel["key"].to_legacy_urlsafe().decode("ASCII")}'
+        return_url = self.get_return_url(order_skel)
         return {
             "merchant_id": self.merchant_id,
             "client_id": self.client_id,

--- a/src/viur/shop/payment_providers/unzer_abstract.py
+++ b/src/viur/shop/payment_providers/unzer_abstract.py
@@ -9,10 +9,10 @@ from unzer.model.base import BaseModel
 from unzer.model.customer import Salutation as UnzerSalutation
 from unzer.model.payment import PaymentState
 from unzer.model.webhook import Events, IP_ADDRESS
-from viur.core import access, current, db, errors, exposed, force_post
-from viur.core.skeleton import SkeletonInstance
 
 from viur import toolkit
+from viur.core import access, current, db, errors, exposed, force_post
+from viur.core.skeleton import SkeletonInstance
 from viur.shop.skeletons import OrderSkel
 from viur.shop.types import *
 from . import PaymentProviderAbstract
@@ -56,6 +56,7 @@ class UnzerClientViURShop(unzer.UnzerClient):
         public_key: str | t.Callable[[], str],
         sandbox: bool | t.Callable[[], bool] = False,
         language: str = "en",
+        client_ip: str = None,
     ):
         # completely overwritten to keep properties
         super(unzer.UnzerClient, self).__init__()
@@ -63,6 +64,7 @@ class UnzerClientViURShop(unzer.UnzerClient):
         self._public_key = public_key
         self._sandbox = sandbox
         self.language = language
+        self.client_ip = client_ip
 
     @property
     def private_key(self) -> str:

--- a/src/viur/shop/payment_providers/unzer_abstract.py
+++ b/src/viur/shop/payment_providers/unzer_abstract.py
@@ -752,8 +752,10 @@ class UnzerAbstract(PaymentProviderAbstract):
             if none is configured.
         """
         try:
-            country = node_skel["shipping_address"]["dest"]["country"]
-        except (KeyError, TypeError):
+            # The referenced skeleton carries its own renderPreparation, which would
+            # turn the select bone's value into a wrapper object instead of the code.
+            country = toolkit.without_render_preparation(node_skel["shipping_address"]["dest"])["country"]
+        except (AttributeError, KeyError, TypeError):
             country = None
         try:
             return self.shop.vat_rate.get_vat_rate_for_country(

--- a/src/viur/shop/payment_providers/unzer_abstract.py
+++ b/src/viur/shop/payment_providers/unzer_abstract.py
@@ -175,8 +175,7 @@ class UnzerAbstract(PaymentProviderAbstract):
         customer = self.client.createOrUpdateCustomer(customer)
         logger.debug(f"{customer = } [RESPONSE]")
 
-        host = current.request.get().request.host_url
-        return_url = f'{host.rstrip("/")}/{self.modulePath.strip("/")}/return_handler?order_key={order_skel["key"].to_legacy_urlsafe().decode("ASCII")}'
+        return_url = self.get_return_url(order_skel)
         unzer_session = current.session.get()["unzer"] = {
             "customer_id": customer.key,
         }

--- a/src/viur/shop/payment_providers/unzer_abstract.py
+++ b/src/viur/shop/payment_providers/unzer_abstract.py
@@ -1,10 +1,11 @@
 import abc
+import collections
 import functools
 import json
 import typing as t  # noqa
 
 import unzer
-from unzer.model import PaymentType
+from unzer.model import Basket, BasketItem, PaymentType
 from unzer.model.base import BaseModel
 from unzer.model.customer import Salutation as UnzerSalutation
 from unzer.model.payment import PaymentState
@@ -16,8 +17,9 @@ from viur.core.skeleton import SkeletonInstance
 from viur.shop.skeletons import OrderSkel
 from viur.shop.types import *
 from . import PaymentProviderAbstract
-from ..globals import SHOP_LOGGER
+from ..globals import MAX_FETCH_LIMIT, SHOP_LOGGER
 from ..services import HOOK_SERVICE, Hook
+from ..skeletons.cart import CartNodeSkel
 from ..types import error_handler, exceptions as e
 
 logger = SHOP_LOGGER.getChild(__name__)
@@ -102,6 +104,14 @@ class UnzerAbstract(PaymentProviderAbstract):
     Provides common functionality for Unzer-based payment providers,
     including API communication and payment type handling.
     """
+
+    currency_code: str = "EUR"
+    """Currency the basket amounts are reported in."""
+
+    # Unzer basket item types (serialized as ``type``).
+    BASKET_ITEM_GOODS: t.Final[str] = "goods"
+    BASKET_ITEM_SHIPMENT: t.Final[str] = "shipment"
+    BASKET_ITEM_VOUCHER: t.Final[str] = "voucher"
 
     def __init__(
         self,
@@ -541,3 +551,214 @@ class UnzerAbstract(PaymentProviderAbstract):
         if isinstance(obj, BaseModel):
             obj = dict(obj)  # Convert to dict first, then process recursively
         return super().model_to_dict(obj)
+
+    def get_customer(self, order_skel: SkeletonInstance) -> unzer.Customer:
+        customer = self.customer_from_order_skel(order_skel)
+        logger.debug(f"{customer=}")
+        customer = self.client.createOrUpdateCustomer(customer)
+        logger.debug(f"{customer=} [RESPONSE]")
+        return customer
+
+    def get_risk_data(self, order_skel: SkeletonInstance) -> unzer.RiskData:
+        risk_data = unzer.RiskData(
+            registrationLevel=(unzer.RegistrationLevel.GUEST if order_skel["customer"] is None
+                               else unzer.RegistrationLevel.REGISTERED),
+            customerGroup=unzer.CustomerGroup.NEUTRAL
+        )
+        if order_skel["customer"] is not None:
+            risk_data.registrationDate = order_skel["customer"]["dest"]["creationdate"]
+            orders = (
+                self.shop.order.skel(bones=("is_paid", "total")).all()
+                .filter("customer.dest.__key__ =", order_skel["customer"]["dest"]["key"])
+                .filter("is_paid =", True)
+                .fetch(MAX_FETCH_LIMIT)
+            )
+            risk_data.confirmedOrders = len(orders)
+            risk_data.confirmedAmount = functools.reduce(lambda total, skel: total + skel["total"], orders, 0)
+        return risk_data
+
+    # --- Basket --------------------------------------------------------------
+
+    def get_basket_id(
+        self,
+        order_skel: SkeletonInstance,
+    ) -> str:
+        """Build a basket from the order's cart and create it at Unzer.
+
+        Klarna requires a basket whose line items reconcile to the order
+        total. The basket is built from the entire cart tree and created via
+        the Unzer API; the returned basket id is passed to the authorize
+        request.
+
+        :param order_skel: The order to derive the basket from.
+        :return: The id of the created Unzer basket.
+        """
+        basket = Basket(
+            amountTotalGross=order_skel["total"],
+            currencyCode=self.currency_code,
+            orderId=order_skel["key"].id_or_name,
+            basketItems=self.build_basket_items(order_skel),
+        )
+        return self.client.createBasket(basket).key
+
+    def build_basket_items(
+        self,
+        order_skel: SkeletonInstance,
+    ) -> list[BasketItem]:
+        """Collect the whole cart tree as Unzer basket items.
+
+        The cart is a tree in which every node may apply its own shipping and
+        (basket-domain) discount on top of the accumulated subtree total
+        ("decorator" principle). This walks the entire tree and emits, per
+        node, one item per article leaf plus — if present — a shipping item
+        and a discount (voucher) item. The item grosses therefore reconcile
+        exactly to ``order_skel["total"]`` (== root ``total_discount_price``).
+
+        :param order_skel: The order whose cart is converted.
+        :return: The basket items for the complete cart.
+        """
+        # The order's cart ref lacks the ``discount`` bone we need for
+        # node-level discounts, so read the root node skeleton fully.
+        root_skel = self.shop.cart.viewSkel("node")
+        if not root_skel.read(order_skel["cart"]["dest"]["key"]):
+            raise ValueError(f'Cannot read root cart node for order {order_skel["key"]!r}')
+
+        basket_items: list[BasketItem] = []
+        node_queue = collections.deque([root_skel])
+        while node_queue:
+            node_skel = node_queue.pop()
+            # Sum of the subtree total as seen by the ``total_discount_price``
+            # computation, i.e. the value the node's discount is applied to.
+            node_base = 0.0
+            for child in self.shop.cart.get_children(node_skel["key"]):
+                if issubclass(child.skeletonCls, CartNodeSkel):
+                    node_queue.append(child)
+                    node_base += child["total_discount_price"] or 0.0
+                else:
+                    basket_items.append(self.build_article_item(child))
+                    node_base += (child.price_.current or 0.0) * child["quantity"]
+
+            if item := self.build_discount_item(node_skel, node_base):
+                basket_items.append(item)
+            if item := self.build_shipping_item(node_skel):
+                basket_items.append(item)
+
+        return basket_items
+
+    def build_article_item(
+        self,
+        leaf_skel: SkeletonInstance,
+    ) -> BasketItem:
+        """Convert a single cart leaf (article) into an Unzer basket item.
+
+        Article-level discounts are already contained in ``price_.current``;
+        basket-level discounts are emitted separately, see
+        :meth:`build_discount_item`.
+
+        :param leaf_skel: The cart item (leaf) to convert.
+        :return: The corresponding Unzer basket item.
+        """
+        price = leaf_skel.price_
+        quantity = int(leaf_skel["quantity"])
+        return BasketItem(
+            basketItemReferenceId=leaf_skel["key"].id_or_name,
+            title=leaf_skel["shop_name"] or leaf_skel["key"].id_or_name,
+            quantity=quantity,
+            kind=self.BASKET_ITEM_GOODS,
+            vat=round(price.vat_rate_percentage * 100),
+            amountPerUnit=price.current_net,
+            amountNet=toolkit.round_decimal(price.current_net * quantity, 2),
+            amountVat=toolkit.round_decimal(price.vat_included * quantity, 2),
+            amountGross=toolkit.round_decimal(price.current * quantity, 2),
+        )
+
+    def build_shipping_item(
+        self,
+        node_skel: SkeletonInstance,
+    ) -> BasketItem | None:
+        """Build the shipping basket item for a cart node, if any.
+
+        :param node_skel: The cart node whose shipping is converted.
+        :return: The shipping basket item, or ``None`` if the node has no
+            (chargeable) shipping.
+        """
+        if not (shipping := node_skel["shipping"]):
+            return None
+        gross = shipping["dest"]["shipping_cost"] or 0.0
+        if not gross:
+            return None
+        # Shipping is taxed at the standard rate (see cart.get_vat_for_node).
+        vat_percent = self.get_shipping_vat_percentage(node_skel)
+        net = Price.gross_to_net(gross, vat_percent / 100.0)
+        return BasketItem(
+            basketItemReferenceId=f'shipping-{node_skel["key"].id_or_name}',
+            title=shipping["dest"]["name"] or "Shipping",
+            quantity=1,
+            kind=self.BASKET_ITEM_SHIPMENT,
+            vat=round(vat_percent),
+            amountPerUnit=toolkit.round_decimal(net, 2),
+            amountNet=toolkit.round_decimal(net, 2),
+            amountVat=toolkit.round_decimal(gross - net, 2),
+            amountGross=toolkit.round_decimal(gross, 2),
+        )
+
+    def build_discount_item(
+        self,
+        node_skel: SkeletonInstance,
+        base: float,
+    ) -> BasketItem | None:
+        """Build the discount (voucher) basket item for a cart node, if any.
+
+        Mirrors :func:`cart.add_discount`: only basket-domain discounts reduce
+        the node total (article-domain discounts are already reflected in the
+        article prices). The discount amount is ``base`` minus the discounted
+        ``base``, matching the ``total_discount_price`` computation.
+
+        :param node_skel: The cart node whose discount is converted.
+        :param base: The subtree total the node's discount is applied to.
+        :return: The voucher basket item, or ``None`` if the node has no
+            applicable basket-domain discount.
+        """
+        if not (discount := node_skel["discount"]):
+            return None
+        if not any(
+            condition["dest"]["application_domain"] == ApplicationDomain.BASKET
+            for condition in discount["dest"]["condition"]
+        ):
+            return None
+        amount = toolkit.round_decimal(base - Price.apply_discount(discount["dest"], base), 2)
+        if not amount:
+            return None
+        return BasketItem(
+            basketItemReferenceId=f'discount-{discount["dest"]["key"].id_or_name}',
+            title=discount["dest"]["name"] or "Discount",
+            quantity=1,
+            kind=self.BASKET_ITEM_VOUCHER,
+            vat=0,
+            amountPerUnit=-amount,
+            amountNet=-amount,
+            amountVat=0.0,
+            amountGross=-amount,
+        )
+
+    def get_shipping_vat_percentage(
+        self,
+        node_skel: SkeletonInstance,
+    ) -> float:
+        """Return the standard VAT percentage for a node's shipping.
+
+        :param node_skel: The cart node providing the shipping country.
+        :return: The standard VAT rate in percent (e.g. ``19.0``), or ``0.0``
+            if none is configured.
+        """
+        try:
+            country = node_skel["shipping_address"]["dest"]["country"]
+        except (KeyError, TypeError):
+            country = None
+        try:
+            return self.shop.vat_rate.get_vat_rate_for_country(
+                country=country, category=VatRateCategory.STANDARD,
+            )
+        except Exception as exc:  # noqa: BLE001 -- fall back to 0 % on any config error
+            logger.warning(f"No standard vat rate for shipping: {exc}")
+            return 0.0

--- a/src/viur/shop/payment_providers/unzer_klarna.py
+++ b/src/viur/shop/payment_providers/unzer_klarna.py
@@ -1,9 +1,8 @@
-import collections
 import typing as t
 
 import unzer
 from unzer import PaymentResponse
-from unzer.model import Basket, BasketItem, PaymentType
+from unzer.model import PaymentType
 from unzer.model.payment import PaymentState
 
 from viur import toolkit
@@ -11,8 +10,6 @@ from viur.core import current
 from viur.core.skeleton import SkeletonInstance
 from .unzer_abstract import UnzerAbstract, log_unzer_error
 from ..globals import SHOP_LOGGER
-from ..skeletons.cart import CartNodeSkel
-from ..types import ApplicationDomain, Price, VatRateCategory
 
 logger = SHOP_LOGGER.getChild(__name__)
 
@@ -30,14 +27,6 @@ class UnzerKlarna(UnzerAbstract):
     """
 
     name: t.Final[str] = "unzer-klarna"
-
-    currency_code: str = "EUR"
-    """Currency the basket amounts are reported in."""
-
-    # Unzer basket item types (serialized as ``type``).
-    BASKET_ITEM_GOODS: t.Final[str] = "goods"
-    BASKET_ITEM_SHIPMENT: t.Final[str] = "shipment"
-    BASKET_ITEM_VOUCHER: t.Final[str] = "voucher"
 
     def __init__(
         self,
@@ -158,189 +147,3 @@ class UnzerKlarna(UnzerAbstract):
     ) -> PaymentType:
         type_id = order_skel["payment"]["payments"][-1]["type_id"]
         return unzer.Klarna(key=type_id)
-
-    # --- Basket --------------------------------------------------------------
-
-    def get_basket_id(
-        self,
-        order_skel: SkeletonInstance,
-    ) -> str:
-        """Build a basket from the order's cart and create it at Unzer.
-
-        Klarna requires a basket whose line items reconcile to the order
-        total. The basket is built from the entire cart tree and created via
-        the Unzer API; the returned basket id is passed to the authorize
-        request.
-
-        :param order_skel: The order to derive the basket from.
-        :return: The id of the created Unzer basket.
-        """
-        basket = Basket(
-            amountTotalGross=order_skel["total"],
-            currencyCode=self.currency_code,
-            orderId=order_skel["key"].id_or_name,
-            basketItems=self.build_basket_items(order_skel),
-        )
-        return self.client.createBasket(basket).key
-
-    def build_basket_items(
-        self,
-        order_skel: SkeletonInstance,
-    ) -> list[BasketItem]:
-        """Collect the whole cart tree as Unzer basket items.
-
-        The cart is a tree in which every node may apply its own shipping and
-        (basket-domain) discount on top of the accumulated subtree total
-        ("decorator" principle). This walks the entire tree and emits, per
-        node, one item per article leaf plus — if present — a shipping item
-        and a discount (voucher) item. The item grosses therefore reconcile
-        exactly to ``order_skel["total"]`` (== root ``total_discount_price``).
-
-        :param order_skel: The order whose cart is converted.
-        :return: The basket items for the complete cart.
-        """
-        # The order's cart ref lacks the ``discount`` bone we need for
-        # node-level discounts, so read the root node skeleton fully.
-        root_skel = self.shop.cart.viewSkel("node")
-        if not root_skel.read(order_skel["cart"]["dest"]["key"]):
-            raise ValueError(f'Cannot read root cart node for order {order_skel["key"]!r}')
-
-        basket_items: list[BasketItem] = []
-        node_queue = collections.deque([root_skel])
-        while node_queue:
-            node_skel = node_queue.pop()
-            # Sum of the subtree total as seen by the ``total_discount_price``
-            # computation, i.e. the value the node's discount is applied to.
-            node_base = 0.0
-            for child in self.shop.cart.get_children(node_skel["key"]):
-                if issubclass(child.skeletonCls, CartNodeSkel):
-                    node_queue.append(child)
-                    node_base += child["total_discount_price"] or 0.0
-                else:
-                    basket_items.append(self.build_article_item(child))
-                    node_base += (child.price_.current or 0.0) * child["quantity"]
-
-            if item := self.build_discount_item(node_skel, node_base):
-                basket_items.append(item)
-            if item := self.build_shipping_item(node_skel):
-                basket_items.append(item)
-
-        return basket_items
-
-    def build_article_item(
-        self,
-        leaf_skel: SkeletonInstance,
-    ) -> BasketItem:
-        """Convert a single cart leaf (article) into an Unzer basket item.
-
-        Article-level discounts are already contained in ``price_.current``;
-        basket-level discounts are emitted separately, see
-        :meth:`build_discount_item`.
-
-        :param leaf_skel: The cart item (leaf) to convert.
-        :return: The corresponding Unzer basket item.
-        """
-        price = leaf_skel.price_
-        quantity = int(leaf_skel["quantity"])
-        return BasketItem(
-            basketItemReferenceId=leaf_skel["key"].id_or_name,
-            title=leaf_skel["shop_name"] or leaf_skel["key"].id_or_name,
-            quantity=quantity,
-            kind=self.BASKET_ITEM_GOODS,
-            vat=round(price.vat_rate_percentage * 100),
-            amountPerUnit=price.current_net,
-            amountNet=toolkit.round_decimal(price.current_net * quantity, 2),
-            amountVat=toolkit.round_decimal(price.vat_included * quantity, 2),
-            amountGross=toolkit.round_decimal(price.current * quantity, 2),
-        )
-
-    def build_shipping_item(
-        self,
-        node_skel: SkeletonInstance,
-    ) -> BasketItem | None:
-        """Build the shipping basket item for a cart node, if any.
-
-        :param node_skel: The cart node whose shipping is converted.
-        :return: The shipping basket item, or ``None`` if the node has no
-            (chargeable) shipping.
-        """
-        if not (shipping := node_skel["shipping"]):
-            return None
-        gross = shipping["dest"]["shipping_cost"] or 0.0
-        if not gross:
-            return None
-        # Shipping is taxed at the standard rate (see cart.get_vat_for_node).
-        vat_percent = self.get_shipping_vat_percentage(node_skel)
-        net = Price.gross_to_net(gross, vat_percent / 100.0)
-        return BasketItem(
-            basketItemReferenceId=f'shipping-{node_skel["key"].id_or_name}',
-            title=shipping["dest"]["name"] or "Shipping",
-            quantity=1,
-            kind=self.BASKET_ITEM_SHIPMENT,
-            vat=round(vat_percent),
-            amountPerUnit=toolkit.round_decimal(net, 2),
-            amountNet=toolkit.round_decimal(net, 2),
-            amountVat=toolkit.round_decimal(gross - net, 2),
-            amountGross=toolkit.round_decimal(gross, 2),
-        )
-
-    def build_discount_item(
-        self,
-        node_skel: SkeletonInstance,
-        base: float,
-    ) -> BasketItem | None:
-        """Build the discount (voucher) basket item for a cart node, if any.
-
-        Mirrors :func:`cart.add_discount`: only basket-domain discounts reduce
-        the node total (article-domain discounts are already reflected in the
-        article prices). The discount amount is ``base`` minus the discounted
-        ``base``, matching the ``total_discount_price`` computation.
-
-        :param node_skel: The cart node whose discount is converted.
-        :param base: The subtree total the node's discount is applied to.
-        :return: The voucher basket item, or ``None`` if the node has no
-            applicable basket-domain discount.
-        """
-        if not (discount := node_skel["discount"]):
-            return None
-        if not any(
-            condition["dest"]["application_domain"] == ApplicationDomain.BASKET
-            for condition in discount["dest"]["condition"]
-        ):
-            return None
-        amount = toolkit.round_decimal(base - Price.apply_discount(discount["dest"], base), 2)
-        if not amount:
-            return None
-        return BasketItem(
-            basketItemReferenceId=f'discount-{discount["dest"]["key"].id_or_name}',
-            title=discount["dest"]["name"] or "Discount",
-            quantity=1,
-            kind=self.BASKET_ITEM_VOUCHER,
-            vat=0,
-            amountPerUnit=-amount,
-            amountNet=-amount,
-            amountVat=0.0,
-            amountGross=-amount,
-        )
-
-    def get_shipping_vat_percentage(
-        self,
-        node_skel: SkeletonInstance,
-    ) -> float:
-        """Return the standard VAT percentage for a node's shipping.
-
-        :param node_skel: The cart node providing the shipping country.
-        :return: The standard VAT rate in percent (e.g. ``19.0``), or ``0.0``
-            if none is configured.
-        """
-        try:
-            country = node_skel["shipping_address"]["dest"]["country"]
-        except (KeyError, TypeError):
-            country = None
-        try:
-            return self.shop.vat_rate.get_vat_rate_for_country(
-                country=country, category=VatRateCategory.STANDARD,
-            )
-        except Exception as exc:  # noqa: BLE001 -- fall back to 0 % on any config error
-            logger.warning(f"No standard vat rate for shipping: {exc}")
-            return 0.0

--- a/src/viur/shop/payment_providers/unzer_klarna.py
+++ b/src/viur/shop/payment_providers/unzer_klarna.py
@@ -68,9 +68,7 @@ class UnzerKlarna(UnzerAbstract):
         customer = self.client.createOrUpdateCustomer(customer)
         logger.debug(f"{customer=} [RESPONSE]")
 
-        host = current.request.get().request.host_url
-        return_url = (f'{host.rstrip("/")}/{self.modulePath.strip("/")}/return_handler'
-                      f'?order_key={order_skel["key"].to_legacy_urlsafe().decode("ASCII")}')
+        return_url = self.get_return_url(order_skel)
 
         # Klarna (BNPL) cannot be charged directly; authorize it first.
         payment = self.client.authorize(

--- a/src/viur/shop/payment_providers/unzer_openbanking_pis.py
+++ b/src/viur/shop/payment_providers/unzer_openbanking_pis.py
@@ -1,0 +1,115 @@
+import typing as t
+
+import unzer
+from unzer.model import PaymentType
+from viur.core import db, errors, exposed
+from viur.core.skeleton import SkeletonInstance
+
+from viur import toolkit
+from .unzer_abstract import UnzerAbstract, log_unzer_error
+from ..globals import SHOP_LOGGER
+from ..services import HOOK_SERVICE, Hook
+from ..types import error_handler
+
+logger = SHOP_LOGGER.getChild(__name__)
+
+
+class UnzerOpenbankingPis(UnzerAbstract):
+    """
+    Unzer Open Banking PIS (Payment Initiation Service) (Direct Bank Transfer) payment method integration for the ViUR Shop.
+    """
+
+    name: t.Final[str] = "unzer-openbanking_pis"
+
+    def get_payment_type(
+        self,
+        order_skel: SkeletonInstance,
+    ) -> PaymentType:
+        type_id = order_skel["payment"]["payments"][-1]["type_id"]
+        return unzer.DirectBankTransfer(key=type_id)
+
+    def get_pending_payment_ids(
+        self,
+        payment: t.Any,
+        order_skel: SkeletonInstance,
+    ) -> set[str]:
+        """Collect the payments whose charge was initiated but has not settled yet.
+
+        Unlike card or wallet payments, a direct bank transfer is not settled when the
+        customer returns from the bank: the charge stays ``pending`` until the money
+        actually arrives, which takes one up to seven business days. Only then does
+        ``amountCharged`` reach the order total and the payment count as paid.
+
+        :param payment: Payment data as returned by :meth:`UnzerAbstract.check_payment_state`,
+            either a single payment or a list of them.
+        :param order_skel: OrderSkel the payment belongs to.
+        :return: Ids of the payments the customer authorized and that await settlement.
+        """
+        payments = payment if isinstance(payment, list) else [payment]
+        return {
+            single_payment.paymentId
+            for single_payment in payments
+            for transaction in (single_payment.transactions or ())
+            if transaction.action == "charge"
+            and transaction.status == "pending"
+            and transaction.amount == order_skel["total"]
+        }
+
+    def mark_payments_pending(
+        self,
+        order_skel: SkeletonInstance,
+        payment_ids: set[str],
+    ) -> SkeletonInstance:
+        """Flag the payments that await settlement on the order.
+
+        The order stays unpaid, so the flag is what tells a shop frontend apart a
+        payment that failed from one that was placed successfully and is on its way.
+
+        :param order_skel: OrderSkel to update.
+        :param payment_ids: Ids of the payments to flag, see :meth:`get_pending_payment_ids`.
+        :return: The written OrderSkel.
+        """
+
+        def set_pending(skel: SkeletonInstance) -> None:
+            for entry in skel["payment"]["payments"]:
+                if entry.get("payment_id") in payment_ids:
+                    entry["pending"] = True
+
+        return toolkit.set_status(
+            key=order_skel["key"],
+            values=set_pending,
+            skel=order_skel,
+        )
+
+    @exposed
+    @log_unzer_error
+    @error_handler
+    def return_handler(
+        self,
+        order_key: db.Key,
+    ) -> t.Any:
+        """Return Endpoint
+
+        Endpoint to which customers are redirected once they have processed a payment on the payment server.
+
+        Overwritten to accept a pending settlement: a transfer the customer just
+        authorized is a successful checkout, even though the order stays unpaid until
+        the money arrives and the webhook marks it as paid.
+        """
+        # TODO: drop this override once check_payment_state can report a pending state
+        order_key = self.shop.api._normalize_external_key(order_key, "order_key")
+        order_skel = self.shop.order.viewSkel()
+        if not order_skel.read(order_key):
+            raise errors.NotFound
+        is_paid, payment = self.check_payment_state(order_skel)
+        if is_paid and order_skel["is_paid"]:
+            logger.info(f'Order {order_skel["key"]} already marked as paid. Nothing to do.')
+        elif is_paid:
+            logger.info(f'Mark order {order_skel["key"]} as paid')
+            order_skel = self.shop.order.set_paid(order_skel)
+        elif pending_payment_ids := self.get_pending_payment_ids(payment, order_skel):
+            logger.info(f'Charge of order {order_skel["key"]} is awaiting settlement')
+            order_skel = self.mark_payments_pending(order_skel, pending_payment_ids)
+        else:
+            return HOOK_SERVICE.dispatch(Hook.PAYMENT_RETURN_HANDLER_ERROR)(order_skel, payment)
+        return HOOK_SERVICE.dispatch(Hook.PAYMENT_RETURN_HANDLER_SUCCESS)(order_skel, payment)

--- a/src/viur/shop/payment_providers/unzer_openbanking_pis.py
+++ b/src/viur/shop/payment_providers/unzer_openbanking_pis.py
@@ -33,7 +33,7 @@ class UnzerOpenbankingPis(UnzerAbstract):
         order_skel: SkeletonInstance,
     ) -> PaymentType:
         type_id = order_skel["payment"]["payments"][-1]["type_id"]
-        return unzer.DirectBankTransfer(key=type_id)
+        return unzer.OpenbankingPis(key=type_id)
 
     def get_pending_payment_ids(
         self,

--- a/src/viur/shop/payment_providers/unzer_openbanking_pis.py
+++ b/src/viur/shop/payment_providers/unzer_openbanking_pis.py
@@ -15,8 +15,15 @@ logger = SHOP_LOGGER.getChild(__name__)
 
 
 class UnzerOpenbankingPis(UnzerAbstract):
-    """
-    Unzer Open Banking PIS (Payment Initiation Service) (Direct Bank Transfer) payment method integration for the ViUR Shop.
+    """Unzer Direct Bank Transfer (Open Banking PIS) for the ViUR Shop.
+
+    Pay-by-bank based on a payment initiation service: the customer is redirected to
+    log into their own online banking and authorizes the transfer there. Available in
+    Germany and Austria in EUR, and replaces Sofort.
+
+    The charge is not settled when the customer returns -- the transfer takes one up
+    to seven business days to arrive. Until then the order remains unpaid and the
+    payment is flagged as pending, see :meth:`return_handler`.
     """
 
     name: t.Final[str] = "unzer-openbanking_pis"

--- a/src/viur/shop/payment_providers/unzer_openbanking_pis.py
+++ b/src/viur/shop/payment_providers/unzer_openbanking_pis.py
@@ -32,6 +32,11 @@ class UnzerOpenbankingPis(UnzerAbstract):
         self,
         order_skel: SkeletonInstance,
     ) -> PaymentType:
+        """Build the payment type from the resource the frontend created.
+
+        :param order_skel: OrderSkel holding the payment attempt.
+        :return: The direct bank transfer payment type to charge.
+        """
         type_id = order_skel["payment"]["payments"][-1]["type_id"]
         return unzer.OpenbankingPis(key=type_id)
 

--- a/src/viur/shop/payment_providers/unzer_paylater_installment.py
+++ b/src/viur/shop/payment_providers/unzer_paylater_installment.py
@@ -60,7 +60,7 @@ class UnzerPaylaterInstallment(UnzerAbstract):
         order_skel = OrderSkel.refresh_billing_address(order_skel)
         errs = super().can_order(order_skel)
         if not order_skel["billing_address"] or not order_skel["billing_address"]["dest"]["birthdate"]:
-            errs.append(ClientError("billing_address has no birthday set"))
+            errs.append(ClientError("billing_address has no birthdate set"))
         return errs
 
     @log_unzer_error

--- a/src/viur/shop/payment_providers/unzer_paylater_installment.py
+++ b/src/viur/shop/payment_providers/unzer_paylater_installment.py
@@ -1,0 +1,174 @@
+import typing as t  # noqa
+
+import unzer
+from unzer import PaymentResponse
+
+from viur import toolkit
+from viur.core import current, errors
+from viur.core.skeleton import SkeletonInstance
+from viur.shop.skeletons import OrderSkel
+from viur.shop.types import *
+from .unzer_abstract import UnzerAbstract, log_unzer_error
+from ..globals import SHOP_LOGGER
+
+logger = SHOP_LOGGER.getChild(__name__)
+
+
+class UnzerPaylaterInstallment(UnzerAbstract):
+    """Unzer Installment (Ratenkauf) for the ViUR Shop.
+
+    Part of Unzer's Buy Now Pay Later offering, available in Germany, Austria and
+    Switzerland. The customer picks a plan during the checkout and pays the purchase
+    in monthly rates; Unzer collects them by direct debit.
+
+    The plans are fetched and presented by the payment component in the frontend,
+    which binds the customer's choice to the payment type resource. Nothing about the
+    plan is therefore needed here -- only the type id the frontend reports back.
+
+    Unzer offers no direct charge for this method: the payment is authorized during
+    the checkout and charged on fulfillment, see :attr:`charge_directly`.
+    """
+
+    name: t.Final[str] = "unzer-paylater_installment"
+
+    def __init__(
+        self,
+        *args: t.Any,
+        charge_directly: bool = False,
+        **kwargs: t.Any,
+    ) -> None:
+        """
+        :param charge_directly: If ``True``, charge the authorized payment right after
+            the checkout. Defaults to ``False``: an installment purchase is charged
+            when the goods ship.
+        """
+        super().__init__(*args, **kwargs)
+        self.charge_directly = charge_directly
+
+    def can_order(
+        self,
+        order_skel: SkeletonInstance_T[OrderSkel],
+    ) -> list[ClientError]:
+        """Reject an order that cannot be authorized.
+
+        Unzer runs a credit check on the customer, for which the date of birth is
+        mandatory -- unlike for the payment methods that are charged right away.
+
+        :param order_skel: OrderSkel to validate.
+        :return: The errors that prevent ordering, empty if there are none.
+        """
+        order_skel = OrderSkel.refresh_billing_address(order_skel)
+        errs = super().can_order(order_skel)
+        if not order_skel["billing_address"] or not order_skel["billing_address"]["dest"]["birthdate"]:
+            errs.append(ClientError("billing_address has no birthday set"))
+        return errs
+
+    @log_unzer_error
+    def checkout(
+        self,
+        order_skel: SkeletonInstance,
+    ) -> t.Any:
+        """Authorize the installment payment.
+
+        Unzer offers no direct charge here: the purchase is authorized during the
+        checkout and captured on fulfillment, unless :attr:`charge_directly` says
+        otherwise. The order therefore stays unpaid when this returns.
+
+        :param order_skel: OrderSkel to pay for.
+        :return: The unzer session data, as stored in the current session.
+        """
+        order_skel = OrderSkel.refresh_billing_address(order_skel)
+        if not order_skel["billing_address"]["dest"]["birthdate"]:
+            raise errors.PreconditionFailed("Billing address has no birthdate")
+
+        # Installment cannot be charged directly; authorize it first.
+        payment = self.client.authorize(
+            self.get_payment_request(order_skel),
+            headers={
+                "x-CLIENTIP": current.request.get().request.client_addr,
+            },
+        )
+        logger.debug(f"{payment=} [authorize response]")
+        unzer_session = current.session.get()["unzer"] = {
+            "customer_id": payment.customerId,
+            "paymentId": payment.paymentId,
+            "redirectUrl": payment.redirectUrl,
+        }
+        logger.debug(f"{unzer_session=}")
+        current.session.get().markChanged()
+
+        processing_data = payment.processing.asDict()
+
+        def set_payment(skel: SkeletonInstance) -> None:
+            skel["payment"]["payments"][-1]["payment_id"] = payment.paymentId
+            skel["payment"]["payments"][-1]["processing_data"] = processing_data
+
+        order_skel = toolkit.set_status(
+            key=order_skel["key"],
+            values=set_payment,
+            skel=order_skel,
+        )
+
+        if self.charge_directly:
+            order_skel, payment = self.charge(order_skel=order_skel, payment=payment)
+
+        return unzer_session
+
+    def charge(
+        self,
+        order_skel: SkeletonInstance_T[OrderSkel],
+        payment: PaymentResponse | None = None,
+    ) -> tuple[SkeletonInstance_T[OrderSkel], PaymentResponse]:
+        """Capture the authorized payment, in full.
+
+        :param order_skel: OrderSkel the payment belongs to.
+        :param payment: (optional) The payment to charge. Defaults to the payment of
+            the order's last payment attempt.
+        :return: The order and the charged payment.
+        """
+        if payment is None:
+            payment = self.client.getPayment(order_skel["payment"]["payments"][-1]["payment_id"])
+        payment = payment.charge(amount=order_skel["total"])
+        logger.debug(f"{payment=} [charge response]")
+        return order_skel, payment
+
+    def get_payment_request(
+        self,
+        order_skel: SkeletonInstance,
+    ) -> unzer.PaymentRequest:
+        """Build the authorize request.
+
+        Installment requires a basket resource whose line items reconcile to the
+        order total, and risk data about the customer.
+
+        :param order_skel: The order to be authorized.
+        :return: The request to authorize.
+        """
+        customer = self.get_customer(order_skel)
+        return unzer.PaymentRequest(
+            self.get_payment_type(order_skel),
+            amount=order_skel["total"],
+            returnUrl=self.get_return_url(order_skel),
+            customerId=customer.key,
+            orderId=order_skel["key"].id_or_name,
+            invoiceId=order_skel["order_uid"],
+            basketId=self.get_basket_id(order_skel),
+            additional_transaction_data=unzer.AdditionalTransactionData(
+                risk_data=self.get_risk_data(order_skel),
+            ),
+        )
+
+    def get_payment_type(
+        self,
+        order_skel: SkeletonInstance,
+    ) -> unzer.PaymentType:
+        """Build the payment type from the resource the frontend created.
+
+        The resource already carries the plan the customer picked and their IBAN,
+        so the type id is all that is needed here.
+
+        :param order_skel: OrderSkel holding the payment attempt.
+        :return: The installment payment type to authorize.
+        """
+        type_id = order_skel["payment"]["payments"][-1]["type_id"]
+        return unzer.PaylaterInstallment(key=type_id)

--- a/src/viur/shop/payment_providers/unzer_paylater_invoice.py
+++ b/src/viur/shop/payment_providers/unzer_paylater_invoice.py
@@ -1,4 +1,3 @@
-import functools
 import typing as t  # noqa
 
 import unzer
@@ -10,7 +9,7 @@ from viur.core.skeleton import SkeletonInstance
 from viur.shop.skeletons import OrderSkel
 from viur.shop.types import *
 from .unzer_abstract import UnzerAbstract, log_unzer_error
-from ..globals import MAX_FETCH_LIMIT, SHOP_LOGGER
+from ..globals import SHOP_LOGGER
 
 logger = SHOP_LOGGER.getChild(__name__)
 
@@ -101,13 +100,6 @@ class UnzerPaylaterInvoice(UnzerAbstract):
         logger.debug(f"{payment=} [charge response]")
         return order_skel, payment
 
-    def get_customer(self, order_skel: SkeletonInstance) -> unzer.Customer:
-        customer = self.customer_from_order_skel(order_skel)
-        logger.debug(f"{customer=}")
-        customer = self.client.createOrUpdateCustomer(customer)
-        logger.debug(f"{customer=} [RESPONSE]")
-        return customer
-
     def get_payment_request(self, order_skel: SkeletonInstance) -> unzer.PaymentRequest:
         customer = self.get_customer(order_skel)
         return_url = self.get_return_url(order_skel)
@@ -123,24 +115,6 @@ class UnzerPaylaterInvoice(UnzerAbstract):
                 risk_data=self.get_risk_data(order_skel),
             )
         )
-
-    def get_risk_data(self, order_skel: SkeletonInstance) -> unzer.RiskData:
-        risk_data = unzer.RiskData(
-            registrationLevel=(unzer.RegistrationLevel.GUEST if order_skel["customer"] is None
-                               else unzer.RegistrationLevel.REGISTERED),
-            customerGroup=unzer.CustomerGroup.NEUTRAL
-        )
-        if order_skel["customer"] is not None:
-            risk_data.registrationDate = order_skel["customer"]["dest"]["creationdate"]
-            orders = (
-                self.shop.order.skel(bones=("is_paid", "total")).all()
-                .filter("customer.dest.__key__ =", order_skel["customer"]["dest"]["key"])
-                .filter("is_paid =", True)
-                .fetch(MAX_FETCH_LIMIT)
-            )
-            risk_data.confirmedOrders = len(orders)
-            risk_data.confirmedAmount = functools.reduce(lambda total, skel: total + skel["total"], orders, 0)
-        return risk_data
 
     @exposed
     @log_unzer_error

--- a/src/viur/shop/payment_providers/unzer_paylater_invoice.py
+++ b/src/viur/shop/payment_providers/unzer_paylater_invoice.py
@@ -39,7 +39,7 @@ class UnzerPaylaterInvoice(UnzerAbstract):
         order_skel = OrderSkel.refresh_billing_address(order_skel)
         errs = super().can_order(order_skel)
         if not order_skel["billing_address"] or not order_skel["billing_address"]["dest"]["birthdate"]:
-            errs.append(ClientError("billing_address has no birthday set"))
+            errs.append(ClientError("billing_address has no birthdate set"))
         return errs
 
     @log_unzer_error

--- a/src/viur/shop/payment_providers/unzer_paylater_invoice.py
+++ b/src/viur/shop/payment_providers/unzer_paylater_invoice.py
@@ -110,9 +110,7 @@ class UnzerPaylaterInvoice(UnzerAbstract):
 
     def get_payment_request(self, order_skel: SkeletonInstance) -> unzer.PaymentRequest:
         customer = self.get_customer(order_skel)
-        host = current.request.get().request.host_url
-        return_url = (f'{host.rstrip("/")}/{self.modulePath.strip("/")}/return_handler'
-                      f'?order_key={order_skel["key"].to_legacy_urlsafe().decode("ASCII")}')
+        return_url = self.get_return_url(order_skel)
         return unzer.PaymentRequest(
             self.get_payment_type(order_skel),
             amount=order_skel["total"],

--- a/src/viur/shop/skeletons/cart.py
+++ b/src/viur/shop/skeletons/cart.py
@@ -142,8 +142,10 @@ def get_vat_for_node(skel: "CartNodeSkel", bone: RecordBone) -> list[dict]:
 
     if shipping := skel["shipping"]:
         try:
-            shipping_country = skel["shipping_address"]["dest"]["country"]
-        except (KeyError, TypeError):
+            # The referenced skeleton carries its own renderPreparation, which would
+            # turn the select bone's value into a wrapper object instead of the code.
+            shipping_country = without_render_preparation(skel["shipping_address"]["dest"])["country"]
+        except (AttributeError, KeyError, TypeError):
             shipping_country = None
         vat_percentage = SHOP_INSTANCE.get().vat_rate.get_vat_rate_for_country(
             country=shipping_country, category=VatRateCategory.STANDARD,


### PR DESCRIPTION
## Summary

Two new Unzer payment methods, plus the groundwork both of them needed.

**`UnzerOpenbankingPis` — Direct Bank Transfer (Open Banking PIS)**
Pay-by-bank: the customer authorizes a transfer in their own online banking.
Unlike a card payment the charge does not settle on return — it stays `pending`
for up to seven business days. `return_handler` therefore accepts an outstanding
settlement as a successful checkout and flags the payment as `pending`, so a
frontend can tell it apart from a failure, while the order stays unpaid until the
webhook reports the settled charge.

**`UnzerPaylaterInstallment` — Installment**
Part of Unzer's BNPL offering. The plans are fetched and presented by the payment
component in the frontend, which binds the customer's choice to the payment type
resource — so no plan handling is needed here, only the type id. Authorized during
the checkout together with a basket and risk data, charged on fulfillment.

**Shared groundwork**
- `get_return_url()` in `PaymentProviderAbstract`: the same two lines built the
  return URL in four providers. The host behind it is now configurable via
  `return_url_host` (string or callable, `None` keeps the request host) — a
  development server is neither publicly reachable nor accepted as a return URL by
  most providers, so it had to be patched in by hand before.
- Basket building moved from `UnzerKlarna`, `get_customer`/`get_risk_data` from
  `UnzerPaylaterInvoice` up into `UnzerAbstract`. Neither is specific to those
  methods, and installment needs all of them.
- Translations for both methods in de/en/fr.

**Fix along the way**
Computing a cart node's vat crashed while an order email was rendered
(`Invalid country code KeyValueWrapper(key='de', …)`): `get_vat_for_node` drops the
renderPreparation of the node, but the address skeleton behind the relation carries
its own, so the select bone handed out a wrapper object instead of the country code.

## Verification

Both flows were run end to end against an Unzer sandbox account, with the payment
resources checked through the API afterwards. Direct bank transfer: charge accepted
and `pending` after return, order flagged accordingly. Installment: plans returned
for the cart amount, authorize accepted with basket and risk data.

Both providers use `unzer.OpenbankingPis` and `unzer.PaylaterInstallment`, which the
SDK ships since 1.5.0 (released), so the `unzer` extra now requires `unzer~=1.5`.
